### PR TITLE
fix(frontend): use literal number for route revalidate config

### DIFF
--- a/airnest_frontend/app/api/currency/rates/route.ts
+++ b/airnest_frontend/app/api/currency/rates/route.ts
@@ -2,7 +2,7 @@
 import { NextResponse } from 'next/server';
 import { getServerRates } from '@currency/server/rates';
 
-export const revalidate = 60 * 60 * 12;
+export const revalidate = 43200; // 12 hours
 
 export async function GET() {
   const rates = await getServerRates();


### PR DESCRIPTION
Next.js static analysis requires literal values for route segment config exports. Replace `60 * 60 * 12` with `43200`.