### PR TITLE
perf(frontend): enable Streaming SSR for homepage with Suspense boundary

### DIFF
--- a/airnest_frontend/app/[locale]/page.tsx
+++ b/airnest_frontend/app/[locale]/page.tsx
@@ -1,39 +1,35 @@
 import { Suspense } from 'react';
 import CategoryScroller from '@search/components/CategoryScroller';
 import AnimatedText from '@sharedUI/AnimatedText';
-import ListHybrid from '@properties/list/List.Hybrid'; 
 import ListSkeleton from '@properties/list/List.Skeleton';
-import { getPropertiesWithPersonalization } from '@properties/server/queries';
-import { getUserContext } from '@auth/server/session'; 
-import { getTranslations, getLocale } from 'next-intl/server';
-import { parseSearchParams, getSearchKey, formatApiParams } from '@properties/utils/searchParams'; 
-import { getServerTranslations } from '@translation/server/serverTranslationService';
+import ListStreamed from '@properties/list/List.Streamed';
+import { getTranslations } from 'next-intl/server';
+import { parseSearchParams, getSearchKey } from '@properties/utils/searchParams';
 
-// 具体的页面UI与数据
+/**
+ * 首页 — Streaming SSR 架构
+ *
+ * 渲染流程：
+ *   1. page.tsx 只做轻量操作（解析 URL 参数、读本地翻译文件），几乎瞬间完成
+ *   2. Shell（AnimatedText + CategoryScroller + 骨架屏）立即流式发送到浏览器
+ *   3. ListStreamed 在 Suspense 内部异步获取房源数据 + 翻译
+ *   4. 数据就绪后，React 流式注入真实房源列表，替换骨架屏
+ *
+ * 效果：用户首先看到完整的页面框架和加载动画，而不是空白页面。
+ */
 interface HomeProps {
   searchParams: Promise<Record<string, string | string[]>>;
 }
 
 export default async function Home({ searchParams }: HomeProps) {
+  // 这些操作都很快：解析 URL 参数、读本地 message 文件
   const resolvedSearchParams = await searchParams;
   const t = await getTranslations('app');
-  const locale = await getLocale();
   const parsedParams = parseSearchParams(resolvedSearchParams);
-  
-  const userContext = await getUserContext();
-  
-  // 服务端始终获取前5条数据，无论是否有搜索参数
-  const apiParams = formatApiParams({
-    ...parsedParams,
-    limit: 5,
-    offset: 0
-  });
-  
-  const { properties: initialProperties, userWishlist } = await getPropertiesWithPersonalization(apiParams);
-  const translationsData = await getServerTranslations(initialProperties, locale, userContext);
-  
+
   return (
     <main className="max-w-[1500px] mx-auto px-6">
+      {/* ─── Shell：立即流式发送给浏览器 ─── */}
       <div className="pt-12 pb-4">
         <AnimatedText
           tagline={t('tagline')}
@@ -45,16 +41,15 @@ export default async function Home({ searchParams }: HomeProps) {
 
       <CategoryScroller />
 
+      {/* ─── 房源列表：Suspense 边界内异步获取，流式注入 ─── */}
+      {/*
+        key = getSearchKey(parsedParams)
+        当搜索参数变化时，Suspense 边界重新挂载，
+        立即显示骨架屏 fallback，同时开始获取新的搜索结果。
+      */}
       <div className="mt-6">
-        <Suspense fallback={<ListSkeleton count={15} />}>
-          <ListHybrid 
-            key={getSearchKey(parsedParams)}
-            initialProperties={initialProperties}
-            translationsData={translationsData}
-            locale={locale}
-            searchParams={parsedParams}
-            initialUserWishlist={userWishlist}
-          />
+        <Suspense key={getSearchKey(parsedParams)} fallback={<ListSkeleton count={15} />}>
+          <ListStreamed searchParams={parsedParams} />
         </Suspense>
       </div>
     </main>

--- a/airnest_frontend/src/features/properties/list/List.Streamed.tsx
+++ b/airnest_frontend/src/features/properties/list/List.Streamed.tsx
@@ -1,0 +1,50 @@
+import { getLocale } from 'next-intl/server';
+import { getUserContext } from '@auth/server/session';
+import { getPropertiesWithPersonalization } from '@properties/server/queries';
+import { getServerTranslations } from '@translation/server/serverTranslationService';
+import { formatApiParams, getSearchKey, type SearchParams } from '@properties/utils/searchParams';
+import ListHybrid from './List.Hybrid';
+
+/**
+ * Streaming SSR 包装组件
+ *
+ * 这个 async Server Component 封装了"慢"的数据获取逻辑：
+ *   1. 从后端拉取房源列表 + 用户收藏
+ *   2. 服务端翻译首屏房源（非英文时）
+ *
+ * 它被设计为放在 <Suspense> 内部使用。当 page.tsx 渲染时：
+ *   - Shell（导航、搜索栏、分类、骨架屏）立即流式发送给浏览器
+ *   - 本组件在后台异步获取数据
+ *   - 数据就绪后，React 将真实内容流式注入，替换骨架屏
+ *
+ * 这就是 React 18 Streaming SSR 的核心模式：
+ * 把 async 数据获取下沉到 Suspense 边界内的子组件，而不是在页面顶层 await。
+ */
+interface ListStreamedProps {
+  searchParams: SearchParams;
+}
+
+export default async function ListStreamed({ searchParams }: ListStreamedProps) {
+  const locale = await getLocale();
+  const userContext = await getUserContext();
+
+  const apiParams = formatApiParams({
+    ...searchParams,
+    limit: 5,
+    offset: 0,
+  });
+
+  const { properties, userWishlist } = await getPropertiesWithPersonalization(apiParams);
+  const translationsData = await getServerTranslations(properties, locale, userContext);
+
+  return (
+    <ListHybrid
+      key={getSearchKey(searchParams)}
+      initialProperties={properties}
+      translationsData={translationsData}
+      locale={locale}
+      searchParams={searchParams}
+      initialUserWishlist={userWishlist}
+    />
+  );
+}


### PR DESCRIPTION
Move heavy data fetching (properties + translations) out of page.tsx into a child async Server Component (List.Streamed), wrapped in Suspense. Shell (AnimatedText, CategoryScroller, skeleton) now streams immediately instead of waiting for backend API + Google Translate to resolve.

Made-with: Cursor