### PR TITLE
feat: add AI natural language search (P0)

### DIFF
--- a/AI_FEATURES_PLAN.md
+++ b/AI_FEATURES_PLAN.md
@@ -1,0 +1,589 @@
+# Airnest AI 功能实现计划
+
+> 目标：为项目增加深度集成的 AI 功能，展示 AI 工程化能力而非简单的 API 调用。
+> 核心原则：AI 功能必须融入现有架构（BFF、Streaming SSR、URL 驱动搜索），而非独立的 demo 页面。
+
+---
+
+## 总览：三个功能按优先级排列
+
+| 优先级 | 功能 | 预计工期 | 技术亮点 | 面试价值 |
+|--------|------|----------|----------|----------|
+| P0 | AI 自然语言搜索 | 2-3 天 | Function Calling + 降级策略 + 现有搜索链路复用 | ⭐⭐⭐⭐⭐ |
+| P1 | AI 评论洞察摘要 | 2-3 天 | 服务端生成 + 缓存失效策略 + 增量更新 | ⭐⭐⭐⭐ |
+| P2 | AI 房源助手 (Concierge) | 4-5 天 | RAG + SSE 流式响应 + 对话状态管理 | ⭐⭐⭐⭐⭐ |
+
+---
+
+## P0：AI 自然语言搜索
+
+### 用户体验
+
+用户在搜索栏输入自然语言描述，AI 将其解析为结构化搜索参数，复用现有搜索链路展示结果。
+
+```
+输入："海边两卧室的公寓，4人住，200美元以内"
+  ↓ AI 解析 (function calling / structured output)
+参数：{ location: "beach", bedrooms: 2, guests: 4, maxPrice: 200 }
+  ↓ router.replace('/?location=beach&guests=4&bedrooms=2&max-price=200')
+结果：现有 Streaming SSR 链路展示结果
+```
+
+### 技术架构
+
+```
+用户在 SearchBar 输入自然语言 → 点击 AI 搜索按钮（或检测到自然语言意图）
+  ↓
+前端: POST /api/search/ai-parse  (BFF Route Handler)
+  ↓
+BFF: 调用 LLM API (OpenAI / Claude) with function calling
+  ↓ 返回结构化 JSON
+前端: router.replace(构建的 URL)
+  ↓ URL 变化触发已有搜索流程
+page.tsx → Suspense → ListStreamed → 后端查询 → 流式返回结果
+```
+
+### 需要改动的文件
+
+#### 后端（Django）— 可选，取决于是否扩展搜索参数
+
+```
+airnest_backend/backend/property/api.py
+  → 扩展 properties_list 视图，支持 bedrooms、max_price 等新筛选参数
+
+airnest_backend/backend/property/urls.py
+  → （如需新端点则添加）
+```
+
+当前后端搜索只支持 location/category/guests/check_in/check_out。
+AI 可能解析出 bedrooms、bathrooms、max_price 等参数。
+需要在后端扩展这些筛选字段的查询支持。
+
+#### 前端 — BFF 路由
+
+```
+新建: airnest_frontend/app/api/search/ai-parse/route.ts
+```
+
+这是核心。一个 Next.js Route Handler，职责：
+1. 接收用户的自然语言输入
+2. 调用 LLM API（OpenAI / Anthropic）做 function calling
+3. 返回结构化搜索参数 JSON
+4. 失败时返回 fallback（将原始输入当作 location 关键词）
+
+```typescript
+// 伪代码 — app/api/search/ai-parse/route.ts
+
+import { NextRequest, NextResponse } from 'next/server';
+
+const SYSTEM_PROMPT = `你是一个房源搜索助手。用户会用自然语言描述他们想要的房源。
+你的任务是从中提取结构化搜索参数。只提取用户明确提到的字段，其余留空。`;
+
+const searchFunction = {
+  name: 'search_properties',
+  description: 'Search for rental properties based on user criteria',
+  parameters: {
+    type: 'object',
+    properties: {
+      location:  { type: 'string', description: '地点/城市/区域' },
+      check_in:  { type: 'string', description: '入住日期 YYYY-MM-DD' },
+      check_out: { type: 'string', description: '退房日期 YYYY-MM-DD' },
+      guests:    { type: 'number', description: '入住人数' },
+      bedrooms:  { type: 'number', description: '卧室数量' },
+      max_price: { type: 'number', description: '每晚最高价格(USD)' },
+      category:  { type: 'string', enum: ['beach', 'cabin', 'countryside', ...] },
+    },
+    required: [],
+  },
+};
+
+export async function POST(req: NextRequest) {
+  const { query, locale } = await req.json();
+
+  try {
+    const response = await callLLM({
+      messages: [
+        { role: 'system', content: SYSTEM_PROMPT },
+        { role: 'user', content: query },
+      ],
+      tools: [{ type: 'function', function: searchFunction }],
+      tool_choice: { type: 'function', function: { name: 'search_properties' } },
+    });
+
+    const params = parseToolCallResult(response);
+    return NextResponse.json({ success: true, params });
+  } catch (error) {
+    // 降级：把用户输入当作地点关键词
+    return NextResponse.json({
+      success: true,
+      params: { location: query },
+      fallback: true,
+    });
+  }
+}
+```
+
+#### 前端 — 搜索 UI 增强
+
+```
+修改: airnest_frontend/src/features/search/components/SearchBar.tsx
+  → 在地点输入框旁增加 AI 搜索模式（如一个切换按钮/图标）
+  → 或检测输入长度 > 阈值时自动视为自然语言
+
+新建: airnest_frontend/src/features/search/hooks/useAISearch.ts
+  → 封装 AI 解析调用逻辑
+  → 处理 loading/error/fallback 状态
+  → 解析返回的参数并调用 replaceUrl()
+
+修改: airnest_frontend/src/features/search/utils/query.ts
+  → SearchState 类型扩展（bedrooms, max_price 等）
+  → buildQuery / parseQuery 支持新字段
+```
+
+#### 前端 — 搜索参数扩展
+
+```
+修改: airnest_frontend/src/features/properties/utils/searchParams.ts
+  → SearchParams 接口添加 bedrooms, bathrooms, max_price 等可选字段
+  → formatApiParams 支持新字段
+```
+
+### 关键设计决策
+
+**1. LLM 选择**
+- 推荐 OpenAI gpt-4o-mini：便宜（$0.15/1M input tokens）、快速、function calling 稳定
+- 备选 Claude 3.5 Haiku：同样便宜且快
+- 密钥存在 BFF 环境变量中，不暴露给浏览器
+
+**2. 降级策略（核心面试点）**
+- AI 调用超时（3s）→ 降级为关键词搜索
+- AI 返回格式异常 → 降级为关键词搜索
+- API 配额耗尽 → 降级为关键词搜索
+- 面试话术："AI 是增强，不是依赖。核心搜索功能不依赖 AI 可用性。"
+
+**3. 成本控制**
+- 短 prompt（<200 tokens input），每次调用成本 < $0.001
+- 可选：对常见 query pattern 做内存缓存（如 "beach apartment" → 直接返回）
+- 可选：频率限制（每用户每分钟 N 次 AI 搜索）
+
+**4. UX 设计**
+- 方案 A：搜索栏旁加一个 ✨ 图标，点击切换到"AI 搜索"模式
+- 方案 B：检测到输入是完整句子（长度 > 15 字符 + 包含关键词）时自动提示
+- 方案 C：保持现有搜索栏不变，单独加一个 AI 搜索入口（如一个浮动按钮）
+- 推荐方案 A，最简洁且用户意图明确
+
+### 验收标准
+
+- [ ] 用自然语言（中/英/法）输入搜索需求，能正确解析为结构化参数
+- [ ] AI 失败时无感降级为传统搜索
+- [ ] 搜索结果通过现有 Streaming SSR 链路渲染
+- [ ] BFF 调用 < 3s（超时则降级）
+- [ ] 无 API 密钥泄露（密钥仅在服务端）
+
+---
+
+## P1：AI 评论洞察摘要
+
+### 用户体验
+
+在房源详情页的评论区顶部，展示 AI 生成的结构化评论摘要。
+
+```
+┌────────────────────────────────────────────────────┐
+│  ✨ AI 评论洞察                    基于 23 条评论   │
+│                                                     │
+│  👍 住客最爱                                        │
+│  • 绝佳的海景位置，步行可达沙滩                       │
+│  • 房东响应极快，提供了丰富的当地推荐                  │
+│  • 厨房设备齐全，适合长住                            │
+│                                                     │
+│  ⚠️ 值得注意                                       │
+│  • 隔音一般，对噪音敏感的住客请注意                    │
+│  • 停车位有限，建议提前沟通                           │
+│                                                     │
+│  👥 最适合：情侣旅行 · 短期度假 · 远程办公            │
+│                                                     │
+│  ⏱ 上次更新：2 天前                                 │
+└────────────────────────────────────────────────────┘
+```
+
+### 技术架构
+
+```
+新评论提交成功
+  ↓
+后端：标记该房源的 AI 摘要为 stale（需要重新生成）
+  ↓
+用户访问房源详情页
+  ↓
+前端请求：GET /api/properties/{id}/ai-review-summary
+  ↓
+BFF 代理 → 后端：
+  ├─ 缓存命中 & 未过期 → 直接返回缓存的摘要
+  └─ 缓存未命中 / 已过期 → 拉取所有评论 → 调用 LLM 生成摘要 → 存入缓存 → 返回
+```
+
+### 需要改动的文件
+
+#### 后端（Django）
+
+```
+新建: airnest_backend/backend/property/ai_service.py
+  → LLM 调用封装
+  → Prompt 模板
+  → 响应解析和验证
+
+修改: airnest_backend/backend/property/models.py
+  → 新增 PropertyReviewSummary 模型（缓存 AI 生成的摘要）
+
+新建: 对应的 migration 文件
+
+修改: airnest_backend/backend/property/api.py
+  → 新增端点 GET /api/properties/{id}/ai-review-summary/
+  → 修改 create_review 视图，新评论提交后标记摘要为 stale
+
+修改: airnest_backend/backend/property/urls.py
+  → 注册新端点
+```
+
+#### 新增模型
+
+```python
+# property/models.py 新增
+
+class PropertyReviewSummary(models.Model):
+    """AI 生成的评论摘要缓存"""
+    id = models.UUIDField(primary_key=True, default=uuid.uuid4, editable=False)
+    property_ref = models.OneToOneField(
+        Property, related_name='ai_review_summary', on_delete=models.CASCADE
+    )
+    
+    # AI 生成的结构化摘要
+    highlights = models.JSONField(default=list)     # ["绝佳海景", "房东热情"]
+    concerns = models.JSONField(default=list)       # ["隔音一般"]
+    best_for = models.JSONField(default=list)       # ["情侣旅行", "短期度假"]
+    summary_text = models.TextField(blank=True)     # 一句话总结
+    
+    # 缓存控制
+    reviews_count_at_generation = models.IntegerField(default=0)
+    is_stale = models.BooleanField(default=False)   # 有新评论时标记
+    generated_at = models.DateTimeField(auto_now=True)
+    model_version = models.CharField(max_length=50, default='gpt-4o-mini')
+    
+    # 多语言：每种语言各存一份
+    locale = models.CharField(max_length=10, default='en')
+    
+    class Meta:
+        unique_together = ['property_ref', 'locale']
+```
+
+#### 前端
+
+```
+新建: airnest_frontend/src/features/properties/reviews/Reviews.AIInsights.tsx
+  → AI 评论洞察 UI 组件
+  → 加载骨架屏
+  → 错误降级（不显示 AI 洞察，不影响评论列表）
+
+修改: airnest_frontend/src/features/properties/reviews/Reviews.Container.tsx
+  → 在 ReviewsSummary 之后添加 AIInsights 组件
+```
+
+### 关键设计决策
+
+**1. 生成时机**
+- 不是实时生成——太慢且太贵
+- 访问时生成 + 缓存：第一个访问者触发生成（~2-3s），后续访问者直接读缓存
+- 新评论提交时标记 stale，下次访问时重新生成
+
+**2. 增量更新（面试加分点）**
+- 如果只新增了 1 条评论，不需要重新分析所有 23 条
+- 将旧摘要 + 新评论一起喂给 AI，让它做增量更新
+- 节省 token 成本，降低延迟
+
+**3. 最低评论数阈值**
+- 评论 < 3 条时不生成 AI 摘要（数据量不足以提供有意义的洞察）
+- 显示 "评论数量不足，暂无 AI 洞察" 的提示
+
+**4. 多语言**
+- 按 locale 分别缓存摘要（en/zh/fr 各一份）
+- 或：只生成英文摘要，前端通过现有翻译系统翻译（更省成本）
+
+### 验收标准
+
+- [ ] 评论 >= 3 条的房源详情页展示 AI 洞察卡片
+- [ ] 摘要有缓存，不会每次访问都调用 LLM
+- [ ] 新评论提交后，下次访问能看到更新后的摘要
+- [ ] AI 服务不可用时，评论区正常展示（优雅降级）
+- [ ] 支持中英法三种语言的摘要
+
+---
+
+## P2：AI 房源助手 (Concierge)
+
+### 用户体验
+
+在房源详情页提供一个 AI 对话框，用户可以就该房源提出任何问题。
+
+```
+┌─────────────────────────────────────┐
+│  🤖 AI 房源助手                      │
+│                                      │
+│  👤 这里离最近的超市多远？             │
+│                                      │
+│  🤖 根据房源描述和其他住客的评价，      │
+│     步行约 5 分钟可到达一家杂货店。     │
+│     房东 John 也提到附近有一家...       │
+│     （正在输入中 ▊）                  │
+│                                      │
+│  ┌──────────────────────────────┐    │
+│  │ 输入你的问题...         发送  │    │
+│  └──────────────────────────────┘    │
+└─────────────────────────────────────┘
+```
+
+### 技术架构
+
+```
+用户在详情页打开 AI 助手面板 → 输入问题
+  ↓
+前端: POST /api/ai/concierge (BFF Route Handler)
+  body: { propertyId, question, conversationHistory }
+  ↓
+BFF:
+  1. 通过 BFF 代理从后端获取房源详情 + 评论（作为 RAG context）
+  2. 构建 prompt: system(角色+规则) + context(房源数据) + history + user question
+  3. 调用 LLM with streaming
+  4. 通过 SSE (Server-Sent Events) 流式返回给前端
+  ↓
+前端: ReadableStream → 逐字显示 AI 回复（打字机效果）
+```
+
+### 需要改动的文件
+
+#### 前端 — BFF 路由
+
+```
+新建: airnest_frontend/app/api/ai/concierge/route.ts
+  → SSE 流式响应的 Route Handler
+  → RAG context 组装（房源描述、设施、评论摘要）
+  → 对话历史管理
+  → 安全：限制 context 长度，防止 prompt injection
+```
+
+#### 前端 — UI 组件
+
+```
+新建: airnest_frontend/src/features/ai-concierge/
+  ├── components/
+  │   ├── ConciergePanel.tsx      # 主面板（可折叠的浮动面板）
+  │   ├── ConciergeMessage.tsx    # 单条消息（支持 Markdown 渲染）
+  │   └── ConciergeInput.tsx      # 输入框 + 发送按钮
+  ├── hooks/
+  │   ├── useConcierge.ts         # 对话状态管理 + SSE 流式读取
+  │   └── usePropertyContext.ts   # 获取房源上下文数据
+  └── types/
+      └── types.ts                # 类型定义
+
+修改: airnest_frontend/app/[locale]/properties/[id]/page.tsx
+  → 在详情页底部或侧边添加 ConciergePanel
+```
+
+### RAG Context 设计（核心面试点）
+
+```typescript
+function buildContext(property: PropertyDetail, reviews: Review[]): string {
+  return `
+## 房源信息
+- 名称：${property.title}
+- 位置：${property.city}, ${property.country}
+- 类型：${property.place_type}（${property.category}）
+- 容量：${property.guests} 人，${property.bedrooms} 卧，${property.bathrooms} 卫
+- 价格：$${property.price_per_night}/晚
+- 设施标签：${property.property_tags.join(', ')}
+
+## 房源描述
+${property.description}
+
+## 住客评价摘要（共 ${reviews.length} 条）
+${reviews.slice(0, 10).map(r => `- [${r.rating}星] ${r.content.slice(0, 200)}`).join('\n')}
+`;
+}
+```
+
+### SSE 流式响应实现
+
+```typescript
+// app/api/ai/concierge/route.ts 伪代码
+
+export async function POST(req: NextRequest) {
+  const { propertyId, question, history } = await req.json();
+  
+  // 1. 获取房源上下文（通过 BFF 代理）
+  const [property, reviews] = await Promise.all([
+    fetchPropertyDetail(propertyId),
+    fetchPropertyReviews(propertyId),
+  ]);
+  
+  const context = buildContext(property, reviews);
+  
+  // 2. 调用 LLM with streaming
+  const stream = await callLLMStream({
+    messages: [
+      { role: 'system', content: CONCIERGE_SYSTEM_PROMPT },
+      { role: 'system', content: `房源上下文：\n${context}` },
+      ...history,
+      { role: 'user', content: question },
+    ],
+  });
+  
+  // 3. 转为 SSE 返回
+  return new Response(stream, {
+    headers: {
+      'Content-Type': 'text/event-stream',
+      'Cache-Control': 'no-cache',
+      'Connection': 'keep-alive',
+    },
+  });
+}
+```
+
+### 关键设计决策
+
+**1. Context 长度控制**
+- 房源描述：截断到 500 字符
+- 评论：最多取 10 条最新/最相关的，每条截断到 200 字符
+- 对话历史：只保留最近 6 轮（12 条消息）
+- 总 context < 2000 tokens，控制成本
+
+**2. 安全防护**
+- 用户输入过滤：检测并拒绝 prompt injection 尝试
+- 回答范围限制：system prompt 明确限定只回答与该房源相关的问题
+- 敏感信息过滤：不暴露房东私人信息（联系方式等）
+
+**3. 流式 UX**
+- 打字机效果：逐 token 显示回复
+- 中断支持：用户可以中途停止生成（AbortController）
+- 错误处理：流中断时显示"生成被中断"提示
+
+**4. 状态管理**
+- 对话历史保存在组件 state 中（不持久化，刷新清空）
+- 可选：保存到 sessionStorage，同一会话内跨刷新保持
+
+### 验收标准
+
+- [ ] 房源详情页出现 AI 助手入口（浮动按钮或面板）
+- [ ] 能基于房源信息 + 评论回答相关问题
+- [ ] 流式打字机效果显示回复
+- [ ] 不回答与房源无关的问题（如"帮我写代码"）
+- [ ] 网络中断 / LLM 不可用时的优雅降级
+- [ ] 支持多语言对话（检测用户语言，用同语言回复）
+
+---
+
+## 通用工程事项
+
+### 环境变量
+
+```bash
+# .env.local (前端)
+OPENAI_API_KEY=sk-...               # 只在 BFF 服务端可访问
+AI_MODEL=gpt-4o-mini                # 默认模型
+AI_TIMEOUT_MS=5000                   # AI 调用超时
+AI_MAX_REQUESTS_PER_MIN=20          # 每用户每分钟限制
+
+# .env (后端, P1 需要)
+OPENAI_API_KEY=sk-...               # 后端直接调用（评论摘要生成）
+```
+
+### LLM 调用封装（前后端共用模式）
+
+无论前端 BFF 还是后端 Django，都应该有一个统一的 LLM 调用封装：
+
+```
+前端 BFF:
+  新建: airnest_frontend/src/shared/ai/llm-client.ts
+  → 封装 OpenAI / Anthropic SDK 调用
+  → 超时控制、重试、错误分类
+  → 统一的日志和监控埋点
+
+后端 Django (P1):
+  新建: airnest_backend/backend/property/ai_service.py
+  → 同样的封装，Python 版本
+```
+
+### 成本监控
+
+- 每次 AI 调用记录 token 消耗
+- 设置月度预算告警（如 $10/月）
+- Dashboard 或日志中可查看：
+  - 每日调用次数
+  - 平均 token 消耗
+  - 平均延迟
+  - 错误率
+
+### 频率限制
+
+```
+AI 搜索 (P0):  每用户 20 次/分钟（防滥用）
+评论摘要 (P1):  每房源每小时最多触发 1 次生成（防重复调用）
+AI 助手 (P2):  每用户 10 条消息/分钟（防刷）
+```
+
+---
+
+## 实施时间线
+
+### 第 1 周：P0 — AI 自然语言搜索
+
+| 天 | 任务 |
+|----|------|
+| Day 1 | 后端扩展搜索参数（bedrooms, max_price 等）；前端 SearchState 类型扩展 |
+| Day 2 | BFF Route Handler 实现：LLM 调用 + function calling + 降级逻辑 |
+| Day 3 | SearchBar UI 增强：AI 搜索模式切换；useAISearch hook；端到端测试 |
+
+### 第 2 周：P1 — AI 评论洞察摘要
+
+| 天 | 任务 |
+|----|------|
+| Day 4 | 后端：PropertyReviewSummary 模型 + migration；ai_service.py LLM 封装 |
+| Day 5 | 后端：摘要生成逻辑 + API 端点；缓存失效逻辑（新评论触发 stale） |
+| Day 6 | 前端：Reviews.AIInsights 组件；集成到详情页；多语言支持 |
+
+### 第 3 周：P2 — AI 房源助手
+
+| 天 | 任务 |
+|----|------|
+| Day 7 | BFF：SSE 流式 Route Handler；RAG context 组装；安全过滤 |
+| Day 8 | 前端：ConciergePanel + ConciergeMessage 组件；useConcierge hook（SSE 读取） |
+| Day 9 | 前端：打字机效果；中断支持；对话历史管理 |
+| Day 10 | 集成到详情页；UX 打磨（浮动面板动画、移动端适配） |
+| Day 11 | 全功能端到端测试；性能调优；文档更新 |
+
+---
+
+## 面试叙事框架
+
+### 被问到"为什么加 AI"时
+
+> "用户用自然语言描述需求比手动填 5 个表单字段更高效。AI 在这里解决了一个
+> 真实的 UX 问题。同时我设计了完整的降级策略——AI 不可用时无感回退到传统
+> 搜索，核心功能不依赖 AI 的可用性。"
+
+### 被问到"技术实现细节"时
+
+> "我用 LLM function calling 将自然语言转为结构化参数，这些参数直接复用
+> 现有的 URL 驱动搜索架构——同一套 Streaming SSR 链路，同一套后端查询逻辑。
+> AI 只是在 BFF 层加了一步语义解析，没有引入任何新的数据流。"
+
+### 被问到"成本和可扩展性"时
+
+> "每次 AI 搜索约消耗 200 tokens，成本 < $0.001。我设了每用户频率限制，
+> 也做了常见 query 的缓存。评论摘要采用生成+缓存策略，只在有新评论时
+> 重新生成，避免重复调用。"
+
+### 被问到"RAG 实现"时
+
+> "房源助手使用 RAG 模式：将房源描述、设施标签、最近 10 条评论作为 context
+> 注入 prompt。我做了 context 长度控制（< 2000 tokens）和安全过滤
+> （限定只回答房源相关问题）。响应通过 SSE 流式传输，前端实现打字机效果。"

--- a/airnest_backend/backend/property/api.py
+++ b/airnest_backend/backend/property/api.py
@@ -899,7 +899,40 @@ def properties_with_reviews(request):
                 properties = properties.filter(guests__gte=guests_int)
             except ValueError:
                 pass
-        
+
+        # AI 搜索扩展筛选：bedrooms / bathrooms / price range / place_type
+        bedrooms = request.GET.get('bedrooms', None)
+        if bedrooms:
+            try:
+                properties = properties.filter(bedrooms__gte=int(bedrooms))
+            except ValueError:
+                pass
+
+        bathrooms = request.GET.get('bathrooms', None)
+        if bathrooms:
+            try:
+                properties = properties.filter(bathrooms__gte=int(bathrooms))
+            except ValueError:
+                pass
+
+        max_price = request.GET.get('max_price', None)
+        if max_price:
+            try:
+                properties = properties.filter(price_per_night__lte=float(max_price))
+            except ValueError:
+                pass
+
+        min_price = request.GET.get('min_price', None)
+        if min_price:
+            try:
+                properties = properties.filter(price_per_night__gte=float(min_price))
+            except ValueError:
+                pass
+
+        place_type = request.GET.get('place_type', None)
+        if place_type:
+            properties = properties.filter(place_type__iexact=place_type)
+
         # 分页逻辑 - 添加limit和offset参数支持
         limit = request.GET.get('limit', None)
         offset = request.GET.get('offset', None)

--- a/airnest_frontend/app/api/search/ai-parse/route.ts
+++ b/airnest_frontend/app/api/search/ai-parse/route.ts
@@ -1,0 +1,192 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { callWithTools, type ToolCallResult } from '@/src/shared/ai/llm-client';
+import type OpenAI from 'openai';
+
+/**
+ * AI 自然语言搜索解析
+ *
+ * 接收用户的自然语言描述，通过 LLM function calling 提取结构化搜索参数。
+ * 失败时降级：将原始输入作为 location 关键词返回。
+ */
+
+export interface AISearchParams {
+  location?: string;
+  check_in?: string;
+  check_out?: string;
+  guests?: number;
+  bedrooms?: number;
+  bathrooms?: number;
+  min_price?: number;
+  max_price?: number;
+  category?: string;
+  place_type?: string;
+}
+
+const SYSTEM_PROMPT = `You are a search assistant for a vacation rental platform (like Airbnb).
+The user will describe what they are looking for in natural language (in any language).
+Your task is to extract structured search parameters by calling the search_properties function.
+
+Rules:
+- Always try to extract at least one parameter. Even a single keyword should map to something.
+- If the input matches or closely resembles a category name (apartment, beach house, castle, hotel, etc.), set the "category" field.
+- If the input looks like a place/city/country name, set "location".
+- If the input contains both location and property type info, set both fields.
+- For location, extract the place name in English (e.g. "巴黎" → "Paris").
+- For dates, use YYYY-MM-DD format. If relative (e.g. "next weekend"), calculate from today: ${new Date().toISOString().split('T')[0]}.
+- For price, always convert to USD per night.
+- For category, pick the closest match from: apartment, beach house, bed and breakfast, castle, farm house, ferry, hotel, house, treehouse.
+- Only return an empty object if the input is completely irrelevant nonsense.
+
+Examples:
+- "apartment" → { "category": "apartment" }
+- "Paris" → { "location": "Paris" }
+- "beach house in Vancouver under 200" → { "category": "beach house", "location": "Vancouver", "max_price": 200 }
+- "3 bedrooms Tokyo" → { "location": "Tokyo", "bedrooms": 3 }`;
+
+const searchTool: OpenAI.ChatCompletionTool = {
+  type: 'function',
+  function: {
+    name: 'search_properties',
+    description: 'Search for rental properties based on structured criteria extracted from user input.',
+    parameters: {
+      type: 'object',
+      properties: {
+        location: {
+          type: 'string',
+          description: 'City, region, or area name (in English)',
+        },
+        check_in: {
+          type: 'string',
+          description: 'Check-in date in YYYY-MM-DD format',
+        },
+        check_out: {
+          type: 'string',
+          description: 'Check-out date in YYYY-MM-DD format',
+        },
+        guests: {
+          type: 'number',
+          description: 'Number of guests (minimum 1)',
+        },
+        bedrooms: {
+          type: 'number',
+          description: 'Minimum number of bedrooms',
+        },
+        bathrooms: {
+          type: 'number',
+          description: 'Minimum number of bathrooms',
+        },
+        min_price: {
+          type: 'number',
+          description: 'Minimum price per night in USD',
+        },
+        max_price: {
+          type: 'number',
+          description: 'Maximum price per night in USD',
+        },
+        category: {
+          type: 'string',
+          enum: [
+            'apartment',
+            'beach house',
+            'bed and breakfast',
+            'castle',
+            'farm house',
+            'ferry',
+            'hotel',
+            'house',
+            'treehouse',
+          ],
+          description: 'Property category type',
+        },
+        place_type: {
+          type: 'string',
+          enum: ['entire_place', 'private_room', 'shared_room'],
+          description: 'Type of place/accommodation',
+        },
+      },
+      required: [],
+    },
+  },
+};
+
+export async function POST(request: NextRequest) {
+  try {
+    const body = await request.json();
+    const query = body.query?.trim();
+    console.log('[AI Parse] Received query:', query);
+
+    if (!query) {
+      console.log('[AI Parse] Empty query, returning 400');
+      return NextResponse.json({ error: 'Missing query' }, { status: 400 });
+    }
+
+    const hasKey = !!process.env.OPENROUTER_API_KEY;
+    console.log('[AI Parse] OPENROUTER_API_KEY present:', hasKey);
+    if (!hasKey) {
+      console.log('[AI Parse] No API key, returning fallback');
+      return NextResponse.json(buildFallback(query, 'AI service not configured'));
+    }
+
+    console.log('[AI Parse] Calling LLM with model:', process.env.AI_MODEL || 'google/gemini-2.0-flash-001');
+    const result: ToolCallResult<AISearchParams> = await callWithTools<AISearchParams>({
+      messages: [
+        { role: 'system', content: SYSTEM_PROMPT },
+        { role: 'user', content: query },
+      ],
+      tools: [searchTool],
+      toolChoice: { type: 'function', function: { name: 'search_properties' } },
+    });
+
+    console.log('[AI Parse] LLM result:', JSON.stringify(result));
+
+    if (!result.success || !result.data) {
+      console.log('[AI Parse] LLM failed, returning fallback. Error:', result.error);
+      return NextResponse.json(buildFallback(query, result.error));
+    }
+
+    const params = sanitize(result.data);
+    console.log('[AI Parse] Sanitized params:', JSON.stringify(params));
+
+    const response = {
+      success: true,
+      params,
+      fallback: false,
+      raw_query: query,
+    };
+    console.log('[AI Parse] Returning success response');
+    return NextResponse.json(response);
+  } catch (error) {
+    const msg = error instanceof Error ? error.message : 'Unknown error';
+    console.error('[AI Parse] Uncaught error:', msg);
+
+    const query = (await request.json().catch(() => ({}))).query || '';
+    return NextResponse.json(buildFallback(query, msg));
+  }
+}
+
+function buildFallback(query: string, reason?: string) {
+  return {
+    success: true,
+    params: { location: query } as AISearchParams,
+    fallback: true,
+    fallback_reason: reason,
+    raw_query: query,
+  };
+}
+
+function sanitize(raw: AISearchParams): AISearchParams {
+  const p: AISearchParams = {};
+
+  if (raw.location && typeof raw.location === 'string') p.location = raw.location.trim();
+  if (raw.check_in && /^\d{4}-\d{2}-\d{2}$/.test(raw.check_in)) p.check_in = raw.check_in;
+  if (raw.check_out && /^\d{4}-\d{2}-\d{2}$/.test(raw.check_out)) p.check_out = raw.check_out;
+  if (typeof raw.guests === 'number' && raw.guests >= 1) p.guests = Math.floor(raw.guests);
+  if (typeof raw.bedrooms === 'number' && raw.bedrooms >= 1) p.bedrooms = Math.floor(raw.bedrooms);
+  if (typeof raw.bathrooms === 'number' && raw.bathrooms >= 1) p.bathrooms = Math.floor(raw.bathrooms);
+  if (typeof raw.min_price === 'number' && raw.min_price > 0) p.min_price = raw.min_price;
+  if (typeof raw.max_price === 'number' && raw.max_price > 0) p.max_price = raw.max_price;
+  if (raw.category) p.category = raw.category;
+  if (raw.place_type) p.place_type = raw.place_type;
+
+  return p;
+}

--- a/airnest_frontend/package-lock.json
+++ b/airnest_frontend/package-lock.json
@@ -19,6 +19,7 @@
         "framer-motion": "^12.11.0",
         "next": "15.1.2",
         "next-intl": "^4.1.0",
+        "openai": "^6.32.0",
         "react": "^19.0.0",
         "react-day-picker": "^9.9.0",
         "react-dom": "^19.0.0",
@@ -954,6 +955,16 @@
       },
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/zod": {
+      "version": "3.25.76",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
+      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
       }
     },
     "node_modules/@next/bundle-analyzer": {
@@ -2553,6 +2564,27 @@
         }
       }
     },
+    "node_modules/engine.io-client/node_modules/ws": {
+      "version": "8.17.1",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.17.1.tgz",
+      "integrity": "sha512-6XQFvXTkbfUOZOKKILFG1PDK2NDQs4azKQl26T0YS5CxqWLgXajbPZ+h4gZekJyRqFU8pvnbAbbs/3TgRPy+GQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/engine.io-parser": {
       "version": "5.2.3",
       "resolved": "https://registry.npmjs.org/engine.io-parser/-/engine.io-parser-5.2.3.tgz",
@@ -2575,6 +2607,27 @@
       },
       "peerDependenciesMeta": {
         "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/engine.io/node_modules/ws": {
+      "version": "8.17.1",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.17.1.tgz",
+      "integrity": "sha512-6XQFvXTkbfUOZOKKILFG1PDK2NDQs4azKQl26T0YS5CxqWLgXajbPZ+h4gZekJyRqFU8pvnbAbbs/3TgRPy+GQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
           "optional": true
         }
       }
@@ -3200,6 +3253,16 @@
       },
       "engines": {
         "node": "*"
+      }
+    },
+    "node_modules/eslint/node_modules/zod": {
+      "version": "3.25.76",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
+      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
       }
     },
     "node_modules/espree": {
@@ -5571,6 +5634,27 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/openai": {
+      "version": "6.32.0",
+      "resolved": "https://registry.npmjs.org/openai/-/openai-6.32.0.tgz",
+      "integrity": "sha512-j3k+BjydAf8yQlcOI7WUQMQTbbF5GEIMAE2iZYCOzwwB3S2pCheaWYp+XZRNAch4jWVc52PMDGRRjutao3lLCg==",
+      "license": "Apache-2.0",
+      "bin": {
+        "openai": "bin/cli"
+      },
+      "peerDependencies": {
+        "ws": "^8.18.0",
+        "zod": "^3.25 || ^4.0"
+      },
+      "peerDependenciesMeta": {
+        "ws": {
+          "optional": true
+        },
+        "zod": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/opener": {
       "version": "1.5.2",
       "resolved": "https://registry.npmjs.org/opener/-/opener-1.5.2.tgz",
@@ -6836,6 +6920,27 @@
         }
       }
     },
+    "node_modules/socket.io-adapter/node_modules/ws": {
+      "version": "8.17.1",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.17.1.tgz",
+      "integrity": "sha512-6XQFvXTkbfUOZOKKILFG1PDK2NDQs4azKQl26T0YS5CxqWLgXajbPZ+h4gZekJyRqFU8pvnbAbbs/3TgRPy+GQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/socket.io-client": {
       "version": "4.8.1",
       "resolved": "https://registry.npmjs.org/socket.io-client/-/socket.io-client-4.8.1.tgz",
@@ -7945,10 +8050,12 @@
       "license": "ISC"
     },
     "node_modules/ws": {
-      "version": "8.17.1",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.17.1.tgz",
-      "integrity": "sha512-6XQFvXTkbfUOZOKKILFG1PDK2NDQs4azKQl26T0YS5CxqWLgXajbPZ+h4gZekJyRqFU8pvnbAbbs/3TgRPy+GQ==",
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.20.0.tgz",
+      "integrity": "sha512-sAt8BhgNbzCtgGbt2OxmpuryO63ZoDk/sqaB/znQm94T4fCEsy/yV+7CdC1kJhOU9lboAEU7R3kquuycDoibVA==",
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "engines": {
         "node": ">=10.0.0"
       },
@@ -8000,23 +8107,24 @@
       }
     },
     "node_modules/zod": {
-      "version": "3.24.4",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-3.24.4.tgz",
-      "integrity": "sha512-OdqJE9UDRPwWsrHjLN2F8bPxvwJBK22EHLWtanu0LSYr5YqzsaaW3RMgmjwr8Rypg5k+meEJdSPXJZXE/yqOMg==",
-      "dev": true,
+      "version": "4.3.6",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
+      "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
+      "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }
     },
     "node_modules/zod-to-json-schema": {
-      "version": "3.24.5",
-      "resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.24.5.tgz",
-      "integrity": "sha512-/AuWwMP+YqiPbsJx5D6TfgRTc4kTLjsh5SOcd4bLsfUg2RcEXrFMJl1DGgdHy2aCfsIA/cr/1JM0xcB2GZji8g==",
+      "version": "3.25.1",
+      "resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.25.1.tgz",
+      "integrity": "sha512-pM/SU9d3YAggzi6MtR4h7ruuQlqKtad8e9S0fmxcMi+ueAK5Korys/aWcV9LIIHTVbj01NdzxcnXSN+O74ZIVA==",
       "dev": true,
       "license": "ISC",
       "peerDependencies": {
-        "zod": "^3.24.1"
+        "zod": "^3.25 || ^4"
       }
     },
     "node_modules/zustand": {

--- a/airnest_frontend/package.json
+++ b/airnest_frontend/package.json
@@ -33,6 +33,7 @@
     "framer-motion": "^12.11.0",
     "next": "15.1.2",
     "next-intl": "^4.1.0",
+    "openai": "^6.32.0",
     "react": "^19.0.0",
     "react-day-picker": "^9.9.0",
     "react-dom": "^19.0.0",

--- a/airnest_frontend/src/features/properties/utils/searchParams.ts
+++ b/airnest_frontend/src/features/properties/utils/searchParams.ts
@@ -12,6 +12,12 @@ export interface SearchParams {
   page?: number;
   limit?: number;
   offset?: number;
+  // AI 搜索扩展字段
+  bedrooms?: number;
+  bathrooms?: number;
+  minPrice?: number;
+  maxPrice?: number;
+  placeType?: string;
 }
 
 /**
@@ -20,20 +26,35 @@ export interface SearchParams {
  * @returns 标准化的搜索参数对象
  */
 export function parseSearchParams(searchParams: URLSearchParams | Record<string, string | string[]>): SearchParams {
-  // 统一处理不同的输入格式
   const params = searchParams instanceof URLSearchParams 
     ? searchParams 
     : new URLSearchParams(Object.entries(searchParams).map(([key, value]) => [key, Array.isArray(value) ? value[0] : value]).filter(([_, value]) => value));
 
+  const optInt = (v: string | null) => {
+    if (!v) return undefined;
+    const n = parseInt(v, 10);
+    return Number.isFinite(n) && n > 0 ? n : undefined;
+  };
+  const optFloat = (v: string | null) => {
+    if (!v) return undefined;
+    const n = parseFloat(v);
+    return Number.isFinite(n) && n > 0 ? n : undefined;
+  };
+
   return {
     where: params.get('where') || params.get('location') || '',
-    checkIn: params.get('check-in') || '',
-    checkOut: params.get('check-out') || '',
+    checkIn: params.get('check-in') || params.get('check_in') || '',
+    checkOut: params.get('check-out') || params.get('check_out') || '',
     guests: Math.max(1, parseInt(params.get('guests') || '1')),
     category: params.get('category') || '',
     page: parseInt(params.get('page') || '1'),
     limit: parseInt(params.get('limit') || '20'),
-    offset: parseInt(params.get('offset') || '0')
+    offset: parseInt(params.get('offset') || '0'),
+    bedrooms: optInt(params.get('bedrooms')),
+    bathrooms: optInt(params.get('bathrooms')),
+    minPrice: optFloat(params.get('min_price')),
+    maxPrice: optFloat(params.get('max_price')),
+    placeType: params.get('place_type') || undefined,
   };
 }
 
@@ -85,16 +106,21 @@ export function buildSearchQuery(params: Partial<SearchParams>): URLSearchParams
  * URL参数变化时，组件会重新挂载
  */
 export function getSearchKey(params: SearchParams): string {
-  const keyParams = {
+  const keyParams: Record<string, unknown> = {
     where: params.where,
     checkIn: params.checkIn,
     checkOut: params.checkOut,
     guests: params.guests,
-    category: params.category
+    category: params.category,
+    bedrooms: params.bedrooms,
+    bathrooms: params.bathrooms,
+    minPrice: params.minPrice,
+    maxPrice: params.maxPrice,
+    placeType: params.placeType,
   };
   
   return Object.entries(keyParams)
-    .filter(([_, value]) => value && value !== '' && value !== 1)
+    .filter(([_, value]) => value != null && value !== '' && value !== 1)
     .map(([key, value]) => `${key}:${value}`)
     .join('|') || 'default';
 }
@@ -146,6 +172,11 @@ export function formatApiParams(params: SearchParams): Record<string, string> {
   if (params.category) apiParams.category = params.category;
   if (params.limit) apiParams.limit = params.limit.toString();
   if (params.offset) apiParams.offset = params.offset.toString();
+  if (params.bedrooms) apiParams.bedrooms = params.bedrooms.toString();
+  if (params.bathrooms) apiParams.bathrooms = params.bathrooms.toString();
+  if (params.minPrice) apiParams.min_price = params.minPrice.toString();
+  if (params.maxPrice) apiParams.max_price = params.maxPrice.toString();
+  if (params.placeType) apiParams.place_type = params.placeType;
   
   return apiParams;
 }

--- a/airnest_frontend/src/features/search/components/SearchBar.tsx
+++ b/airnest_frontend/src/features/search/components/SearchBar.tsx
@@ -4,15 +4,20 @@ import {useEffect, useRef, useState, useCallback, startTransition} from 'react';
 import {AnimatePresence, motion} from 'framer-motion';
 import {useTranslations} from 'next-intl';
 import {useSearchQuery} from '@search/hooks/useSearchQuery';
+import {useAISearch} from '@search/hooks/useAISearch';
 import DatePickerDynamic from '@daysPicker/DayPickerDynamic';
 import {formatDateYYYYMMDD, parseLocalISODate} from '@daysPicker/dateUtils';
 
 export default function SearchBar() {
   const t = useTranslations('search');
   const {state, replaceUrl, isPending} = useSearchQuery();
+  const {search: aiSearch, isLoading: isAILoading, isFallback} = useAISearch();
   const formRef = useRef<HTMLFormElement>(null);
   const locationInputRef = useRef<HTMLInputElement>(null);
+  const aiInputRef = useRef<HTMLInputElement>(null);
 
+  const [isAIMode, setIsAIMode] = useState(false);
+  const [aiQuery, setAIQuery] = useState('');
   const [activeField, setActiveField] = useState<string | null>(null);
   const [locationInput, setLocationInput] = useState(state.location);
   const [isLocationDebouncing, setIsLocationDebouncing] = useState(false);
@@ -90,8 +95,117 @@ export default function SearchBar() {
     return () => document.removeEventListener('mousedown', handler);
   }, []);
 
+  const handleAISubmit = () => {
+    if (!aiQuery.trim() || isAILoading) return;
+    aiSearch(aiQuery);
+    setActiveField(null);
+  };
+
+  const handleAIKeyDown = (e: React.KeyboardEvent) => {
+    if (e.key === 'Enter') {
+      e.preventDefault();
+      handleAISubmit();
+    }
+    if (e.key === 'Escape') setActiveField(null);
+  };
+
   return (
     <div className="w-full max-w-4xl mx-auto">
+      {/* AI / 普通搜索模式切换 */}
+      <div className="flex justify-center mb-3 gap-1">
+        <button
+          type="button"
+          onClick={() => setIsAIMode(false)}
+          className={`px-4 py-1.5 text-xs font-medium rounded-full transition-all duration-200 ${
+            !isAIMode
+              ? 'bg-gray-900 text-white shadow-sm'
+              : 'bg-gray-100 text-gray-600 hover:bg-gray-200'
+          }`}
+        >
+          {t('normalSearch')}
+        </button>
+        <button
+          type="button"
+          onClick={() => { setIsAIMode(true); setTimeout(() => aiInputRef.current?.focus(), 100); }}
+          className={`px-4 py-1.5 text-xs font-medium rounded-full transition-all duration-200 flex items-center gap-1.5 ${
+            isAIMode
+              ? 'bg-gradient-to-r from-violet-600 to-indigo-600 text-white shadow-sm shadow-violet-200'
+              : 'bg-gray-100 text-gray-600 hover:bg-gray-200'
+          }`}
+        >
+          <svg className="w-3.5 h-3.5" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={2}>
+            <path strokeLinecap="round" strokeLinejoin="round" d="M9.813 15.904L9 18.75l-.813-2.846a4.5 4.5 0 00-3.09-3.09L2.25 12l2.846-.813a4.5 4.5 0 003.09-3.09L9 5.25l.813 2.846a4.5 4.5 0 003.09 3.09L15.75 12l-2.846.813a4.5 4.5 0 00-3.09 3.09zM18.259 8.715L18 9.75l-.259-1.035a3.375 3.375 0 00-2.455-2.456L14.25 6l1.036-.259a3.375 3.375 0 002.455-2.456L18 2.25l.259 1.035a3.375 3.375 0 002.455 2.456L21.75 6l-1.036.259a3.375 3.375 0 00-2.455 2.456z" />
+          </svg>
+          {t('aiToggle')}
+        </button>
+      </div>
+
+      <AnimatePresence mode="wait">
+        {isAIMode ? (
+          /* ─── AI 搜索模式 ─── */
+          <motion.div
+            key="ai-mode"
+            initial={{opacity: 0, y: -4}}
+            animate={{opacity: 1, y: 0}}
+            exit={{opacity: 0, y: -4}}
+            transition={{duration: 0.15}}
+          >
+            <form
+              ref={formRef}
+              onSubmit={(e) => { e.preventDefault(); handleAISubmit(); }}
+              className="relative bg-white rounded-full shadow-lg border border-gray-200 overflow-hidden"
+            >
+              <div className="flex items-center">
+                <div className="flex-1 p-4">
+                  <div className="text-xs font-semibold text-gray-900 mb-1">{t('aiSearch')}</div>
+                  <input
+                    ref={aiInputRef}
+                    type="text"
+                    value={aiQuery}
+                    onChange={(e) => setAIQuery(e.target.value)}
+                    onKeyDown={handleAIKeyDown}
+                    placeholder={t('aiPlaceholder')}
+                    className="w-full text-sm text-gray-700 placeholder:text-gray-400 outline-none bg-transparent"
+                    disabled={isAILoading}
+                  />
+                  {isAILoading && (
+                    <div className="mt-1 text-xs text-violet-600 flex items-center gap-1.5">
+                      <div className="animate-spin w-3 h-3 border-2 border-violet-200 border-t-violet-600 rounded-full" />
+                      {t('aiParsing')}
+                    </div>
+                  )}
+                  {isFallback && !isAILoading && (
+                    <div className="mt-1 text-xs text-amber-600">{t('aiFallback')}</div>
+                  )}
+                </div>
+                <div className="pr-2">
+                  <button
+                    type="submit"
+                    disabled={isAILoading || !aiQuery.trim()}
+                    className="bg-gradient-to-r from-violet-600 to-indigo-600 hover:from-violet-700 hover:to-indigo-700 text-white p-4 rounded-full transition-all disabled:opacity-40 disabled:cursor-not-allowed flex items-center justify-center"
+                    aria-label={t('aiSearch')}
+                  >
+                    {isAILoading ? (
+                      <div className="animate-spin w-4 h-4 border-2 border-white border-t-transparent rounded-full" />
+                    ) : (
+                      <svg className="w-4 h-4" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={2}>
+                        <path strokeLinecap="round" strokeLinejoin="round" d="M9.813 15.904L9 18.75l-.813-2.846a4.5 4.5 0 00-3.09-3.09L2.25 12l2.846-.813a4.5 4.5 0 003.09-3.09L9 5.25l.813 2.846a4.5 4.5 0 003.09 3.09L15.75 12l-2.846.813a4.5 4.5 0 00-3.09 3.09z" />
+                      </svg>
+                    )}
+                  </button>
+                </div>
+              </div>
+            </form>
+          </motion.div>
+        ) : (
+          /* ─── 普通搜索模式 ─── */
+          <motion.div
+            key="normal-mode"
+            initial={{opacity: 0, y: -4}}
+            animate={{opacity: 1, y: 0}}
+            exit={{opacity: 0, y: -4}}
+            transition={{duration: 0.15}}
+          >
       <form ref={formRef} className="relative bg-white rounded-full shadow-lg border border-gray-200 overflow-hidden">
         <div className="flex items-center divide-x divide-gray-200">
           {/* 地点 */}
@@ -262,6 +376,9 @@ export default function SearchBar() {
           )}
         </AnimatePresence>
       </form>
+          </motion.div>
+        )}
+      </AnimatePresence>
     </div>
   );
 }

--- a/airnest_frontend/src/features/search/hooks/useAISearch.ts
+++ b/airnest_frontend/src/features/search/hooks/useAISearch.ts
@@ -1,0 +1,98 @@
+'use client';
+
+import { useState, useCallback } from 'react';
+import { useSearchQuery } from './useSearchQuery';
+import type { SearchState } from '@search/utils/query';
+
+interface AISearchResult {
+  success: boolean;
+  params: Record<string, unknown>;
+  fallback: boolean;
+  fallback_reason?: string;
+  raw_query: string;
+}
+
+/**
+ * Hook that sends a natural language query to the AI parse endpoint,
+ * then maps the structured result into URL search params via replaceUrl().
+ *
+ * Falls back to a plain location search if AI fails or is unavailable.
+ */
+export function useAISearch() {
+  const { replaceUrl } = useSearchQuery();
+  const [isLoading, setIsLoading] = useState(false);
+  const [lastResult, setLastResult] = useState<AISearchResult | null>(null);
+
+  const search = useCallback(
+    async (query: string) => {
+      const trimmed = query.trim();
+      if (!trimmed) return;
+
+      console.log('[useAISearch] Starting search with query:', trimmed);
+      setIsLoading(true);
+      setLastResult(null);
+
+      try {
+        console.log('[useAISearch] Calling /api/search/ai-parse...');
+        const res = await fetch('/api/search/ai-parse', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ query: trimmed }),
+        });
+
+        console.log('[useAISearch] Response status:', res.status);
+        if (!res.ok) throw new Error(`HTTP ${res.status}`);
+
+        const data: AISearchResult = await res.json();
+        console.log('[useAISearch] Parsed response:', JSON.stringify(data, null, 2));
+        setLastResult(data);
+
+        const p = data.params;
+        const next: Partial<SearchState> = {};
+
+        if (p.location && typeof p.location === 'string') next.location = p.location;
+        if (p.check_in && typeof p.check_in === 'string') next.check_in = p.check_in;
+        if (p.check_out && typeof p.check_out === 'string') next.check_out = p.check_out;
+        if (typeof p.guests === 'number') next.guests = p.guests;
+        if (typeof p.bedrooms === 'number') next.bedrooms = p.bedrooms;
+        if (typeof p.bathrooms === 'number') next.bathrooms = p.bathrooms;
+        if (typeof p.min_price === 'number') next.min_price = p.min_price;
+        if (typeof p.max_price === 'number') next.max_price = p.max_price;
+        if (p.category && typeof p.category === 'string') next.category = p.category;
+        if (p.place_type && typeof p.place_type === 'string') next.place_type = p.place_type;
+
+        // If AI returned empty params, fall back to raw query as location keyword
+        if (Object.keys(next).length === 0) {
+          console.log('[useAISearch] AI returned empty params, falling back to location keyword:', trimmed);
+          next.location = trimmed;
+        }
+
+        console.log('[useAISearch] Mapped URL params:', JSON.stringify(next));
+        console.log('[useAISearch] Calling replaceUrl...');
+        replaceUrl(next);
+        console.log('[useAISearch] replaceUrl called successfully');
+      } catch (err) {
+        console.error('[useAISearch] Error:', err);
+        replaceUrl({ location: trimmed });
+        setLastResult({
+          success: true,
+          params: { location: trimmed },
+          fallback: true,
+          fallback_reason: err instanceof Error ? err.message : 'Unknown error',
+          raw_query: trimmed,
+        });
+      } finally {
+        setIsLoading(false);
+        console.log('[useAISearch] Done, isLoading set to false');
+      }
+    },
+    [replaceUrl],
+  );
+
+  return {
+    search,
+    isLoading,
+    isFallback: lastResult?.fallback ?? false,
+    lastResult,
+  };
+}

--- a/airnest_frontend/src/features/search/i18n/en.json
+++ b/airnest_frontend/src/features/search/i18n/en.json
@@ -19,6 +19,12 @@
     "searching": "Searching...",
     "oneGuest": "1 guest",
     "guestCount": "{count} guests",
-    "agesInfo": "Ages 13 or above"
+    "agesInfo": "Ages 13 or above",
+    "aiSearch": "AI Search",
+    "aiPlaceholder": "Describe what you're looking for...",
+    "aiParsing": "AI is understanding your request...",
+    "aiFallback": "Showing keyword results",
+    "aiToggle": "Smart Search",
+    "normalSearch": "Filters"
   }
 }

--- a/airnest_frontend/src/features/search/i18n/fr.json
+++ b/airnest_frontend/src/features/search/i18n/fr.json
@@ -19,6 +19,12 @@
     "oneGuest": "1 voyageur",
     "guestCount": "{count} voyageurs",
     "agesInfo": "13 ans ou plus",
-    "searchDestination": "Rechercher une destination"
+    "searchDestination": "Rechercher une destination",
+    "aiSearch": "Recherche IA",
+    "aiPlaceholder": "Décrivez ce que vous cherchez...",
+    "aiParsing": "L'IA analyse votre demande...",
+    "aiFallback": "Résultats par mots-clés",
+    "aiToggle": "Recherche intelligente",
+    "normalSearch": "Filtres"
   }
 }

--- a/airnest_frontend/src/features/search/i18n/zh.json
+++ b/airnest_frontend/src/features/search/i18n/zh.json
@@ -19,6 +19,12 @@
     "oneGuest": "1位客人",
     "guestCount": "{count}位客人",
     "agesInfo": "13岁或以上",
-    "searchDestination": "搜索目的地"
+    "searchDestination": "搜索目的地",
+    "aiSearch": "AI 搜索",
+    "aiPlaceholder": "描述你想要的房源，例如\"巴黎两卧室公寓，200美元以内\"...",
+    "aiParsing": "AI 正在理解你的需求...",
+    "aiFallback": "已切换为关键词搜索",
+    "aiToggle": "智能搜索",
+    "normalSearch": "筛选"
   }
 }

--- a/airnest_frontend/src/features/search/utils/query.ts
+++ b/airnest_frontend/src/features/search/utils/query.ts
@@ -4,10 +4,27 @@ export type SearchState = {
   check_out: string | null;
   guests: number;
   category: string;
+  // AI 搜索扩展字段
+  bedrooms?: number;
+  bathrooms?: number;
+  min_price?: number;
+  max_price?: number;
+  place_type?: string;
 };
 
-// 最小化依赖：任何有 get(name) => string|null 的对象都可
 type SearchParamsLike = { get(name: string): string | null };
+
+function optInt(v: string | null): number | undefined {
+  if (!v) return undefined;
+  const n = parseInt(v, 10);
+  return Number.isFinite(n) && n > 0 ? n : undefined;
+}
+
+function optFloat(v: string | null): number | undefined {
+  if (!v) return undefined;
+  const n = parseFloat(v);
+  return Number.isFinite(n) && n > 0 ? n : undefined;
+}
 
 export function parseQuery(sp: SearchParamsLike): SearchState {
   const get = (k: string) => sp.get(k);
@@ -17,6 +34,11 @@ export function parseQuery(sp: SearchParamsLike): SearchState {
     check_out: get('check_out'),
     guests: Math.max(1, parseInt(get('guests') || '1', 10)),
     category: get('category') ?? '',
+    bedrooms: optInt(get('bedrooms')),
+    bathrooms: optInt(get('bathrooms')),
+    min_price: optFloat(get('min_price')),
+    max_price: optFloat(get('max_price')),
+    place_type: get('place_type') || undefined,
   };
 }
 
@@ -27,5 +49,10 @@ export function buildQuery(s: SearchState): URLSearchParams {
   if (s.check_out) q.set('check_out', s.check_out);
   if (s.guests > 1) q.set('guests', String(s.guests));
   if (s.category) q.set('category', s.category);
+  if (s.bedrooms) q.set('bedrooms', String(s.bedrooms));
+  if (s.bathrooms) q.set('bathrooms', String(s.bathrooms));
+  if (s.min_price) q.set('min_price', String(s.min_price));
+  if (s.max_price) q.set('max_price', String(s.max_price));
+  if (s.place_type) q.set('place_type', s.place_type);
   return q;
 }

--- a/airnest_frontend/src/shared/ai/llm-client.ts
+++ b/airnest_frontend/src/shared/ai/llm-client.ts
@@ -1,0 +1,71 @@
+import 'server-only';
+import OpenAI from 'openai';
+
+const openai = new OpenAI({
+  baseURL: 'https://openrouter.ai/api/v1',
+  apiKey: process.env.OPENROUTER_API_KEY,
+});
+
+const DEFAULT_MODEL = process.env.AI_MODEL || 'google/gemini-2.0-flash-001';
+const DEFAULT_TIMEOUT = Number(process.env.AI_TIMEOUT_MS) || 8000;
+
+export interface ToolCallResult<T = unknown> {
+  success: boolean;
+  data: T | null;
+  fallback: boolean;
+  error?: string;
+}
+
+/**
+ * Call LLM with function calling and return the parsed tool call result.
+ * Handles timeout, parse errors, and API failures gracefully.
+ */
+export async function callWithTools<T>(options: {
+  messages: OpenAI.ChatCompletionMessageParam[];
+  tools: OpenAI.ChatCompletionTool[];
+  toolChoice: OpenAI.ChatCompletionToolChoiceOption;
+  model?: string;
+  timeoutMs?: number;
+}): Promise<ToolCallResult<T>> {
+  const { messages, tools, toolChoice, model = DEFAULT_MODEL, timeoutMs = DEFAULT_TIMEOUT } = options;
+
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), timeoutMs);
+
+  try {
+    console.log(`[LLM] Calling OpenRouter model=${model}, timeout=${timeoutMs}ms`);
+    const response = await openai.chat.completions.create(
+      {
+        model,
+        messages,
+        tools,
+        tool_choice: toolChoice,
+        temperature: 0,
+      },
+      { signal: controller.signal },
+    );
+
+    console.log('[LLM] Raw response choices:', JSON.stringify(response.choices?.[0]?.message));
+
+    const toolCall = response.choices[0]?.message?.tool_calls?.[0] as
+      | { type: 'function'; function: { name: string; arguments: string } }
+      | undefined;
+    if (!toolCall?.function?.arguments) {
+      console.log('[LLM] No tool_calls in response, returning fallback');
+      return { success: false, data: null, fallback: true, error: 'No tool call in response' };
+    }
+
+    console.log('[LLM] Tool call arguments:', toolCall.function.arguments);
+    const parsed = JSON.parse(toolCall.function.arguments) as T;
+    console.log('[LLM] Parsed result:', JSON.stringify(parsed));
+    return { success: true, data: parsed, fallback: false };
+  } catch (err) {
+    const message = err instanceof Error ? err.message : 'Unknown LLM error';
+    const isTimeout = message.includes('aborted');
+    console.error(`[LLM] ${isTimeout ? 'Timeout' : 'Error'}: ${message}`);
+    if (err instanceof Error && err.stack) console.error('[LLM] Stack:', err.stack);
+    return { success: false, data: null, fallback: true, error: message };
+  } finally {
+    clearTimeout(timer);
+  }
+}

--- a/airnest_frontend/src/widgets/navigation/components/SearchFilters.tsx
+++ b/airnest_frontend/src/widgets/navigation/components/SearchFilters.tsx
@@ -1,29 +1,39 @@
 'use client';
 
-import {useState, useEffect, useMemo, Suspense} from 'react';
+import {useState, useEffect, useMemo, useRef, Suspense} from 'react';
 import {useTranslations, useFormatter} from 'next-intl';
 import {motion, AnimatePresence} from 'framer-motion';
 import DatePickerDynamic from '@daysPicker/DayPickerDynamic';
 import SearchModal from '@search/components/SearchModal';
 import {parseLocalISODate, formatDateYYYYMMDD} from '@daysPicker/dateUtils';
 import {useSearchQuery} from '@search/hooks/useSearchQuery';
+import {useAISearch} from '@search/hooks/useAISearch';
 import {useDebouncedCallback} from '@search/hooks/useDebouncedCallback';
+
+const SparkleIcon = ({className = 'w-3.5 h-3.5'}: {className?: string}) => (
+  <svg className={className} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={2}>
+    <path strokeLinecap="round" strokeLinejoin="round" d="M9.813 15.904L9 18.75l-.813-2.846a4.5 4.5 0 00-3.09-3.09L2.25 12l2.846-.813a4.5 4.5 0 003.09-3.09L9 5.25l.813 2.846a4.5 4.5 0 003.09 3.09L15.75 12l-2.846.813a4.5 4.5 0 00-3.09 3.09zM18.259 8.715L18 9.75l-.259-1.035a3.375 3.375 0 00-2.455-2.456L14.25 6l1.036-.259a3.375 3.375 0 002.455-2.456L18 2.25l.259 1.035a3.375 3.375 0 002.455 2.456L21.75 6l-1.036.259a3.375 3.375 0 00-2.455 2.456z" />
+  </svg>
+);
 
 function SearchFiltersContent() {
   const t = useTranslations('search');
   const f = useFormatter();
 
   const {state, replaceUrl, isPending} = useSearchQuery();
+  const {search: aiSearch, isLoading: isAILoading, isFallback} = useAISearch();
+
+  const [isAIMode, setIsAIMode] = useState(false);
+  const [aiQuery, setAIQuery] = useState('');
+  const aiInputRef = useRef<HTMLInputElement>(null);
 
   const [activeFilter, setActiveFilter] = useState<string | null>(null);
   const [showFullSearch, setShowFullSearch] = useState(false);
 
-  // 让输入时更顺滑，避免每键都 replace
   const debouncedSetLocation = useDebouncedCallback((v: string) => {
     replaceUrl({location: v});
   }, 300);
 
-  // 解析 URL 中的 YYYY-MM-DD -> 本地 Date（避免时区偏移）
   const checkInDate = useMemo(
     () => (state.check_in ? parseLocalISODate(state.check_in) : null),
     [state.check_in]
@@ -68,6 +78,27 @@ function SearchFiltersContent() {
     setActiveFilter(null);
   };
 
+  const handleAISubmit = () => {
+    console.log('[SearchFilters] handleAISubmit called, aiQuery:', aiQuery, 'isAILoading:', isAILoading);
+    if (!aiQuery.trim() || isAILoading) {
+      console.log('[SearchFilters] Blocked: empty query or already loading');
+      return;
+    }
+    console.log('[SearchFilters] Dispatching AI search...');
+    aiSearch(aiQuery);
+  };
+
+  const handleAIKeyDown = (e: React.KeyboardEvent) => {
+    if (e.key === 'Enter') { e.preventDefault(); handleAISubmit(); }
+    if (e.key === 'Escape') { setIsAIMode(false); }
+  };
+
+  const switchToAI = () => {
+    setIsAIMode(true);
+    setActiveFilter(null);
+    setTimeout(() => aiInputRef.current?.focus(), 80);
+  };
+
   useEffect(() => {
     const handleClickOutside = (event: MouseEvent) => {
       const target = event.target as HTMLElement;
@@ -84,7 +115,6 @@ function SearchFiltersContent() {
     return () => document.removeEventListener('mousedown', handleClickOutside);
   }, [activeFilter, showFullSearch]);
 
-  // 展示标签
   const checkInLabel = checkInDate
     ? f.dateTime(checkInDate, {month: 'short', day: '2-digit'})
     : t('addDate');
@@ -94,11 +124,84 @@ function SearchFiltersContent() {
 
   return (
     <>
-      {/* 大屏搜索条 */}
-      <div
-        className="hidden lg:flex search-filters-container w-full items-center justify-between border rounded-full transition-all duration-500 ease-in-out relative"
-        style={{height: 'var(--search-height, 48px)'}}
-      >
+      {/* ═══ 大屏搜索条 ═══ */}
+      <AnimatePresence mode="wait">
+        {isAIMode ? (
+          /* ─── AI 搜索模式（大屏） ─── */
+          <motion.div
+            key="ai-bar"
+            initial={{opacity: 0, scale: 0.97}}
+            animate={{opacity: 1, scale: 1}}
+            exit={{opacity: 0, scale: 0.97}}
+            transition={{duration: 0.18}}
+            className="hidden lg:flex search-filters-container w-full items-center border rounded-full relative overflow-hidden"
+            style={{height: 'var(--search-height, 48px)', background: 'linear-gradient(135deg, #fff1f3 0%, #ffe4e8 100%)'}}
+          >
+            <div className="flex-1 flex items-center px-4 gap-2">
+              <SparkleIcon className="w-4 h-4 text-airbnb flex-shrink-0" />
+              <input
+                ref={aiInputRef}
+                type="text"
+                value={aiQuery}
+                onChange={e => setAIQuery(e.target.value)}
+                onKeyDown={handleAIKeyDown}
+                placeholder={t('aiPlaceholder')}
+                className="flex-1 text-sm bg-transparent outline-none text-gray-800 placeholder:text-gray-400"
+                disabled={isAILoading}
+              />
+              {isAILoading && (
+                <span className="text-xs text-airbnb flex items-center gap-1 flex-shrink-0 whitespace-nowrap">
+                  <span className="animate-spin w-3 h-3 border-2 border-red-200 border-t-airbnb rounded-full" />
+                  {t('aiParsing')}
+                </span>
+              )}
+              {isFallback && !isAILoading && (
+                <span className="text-xs text-amber-600 flex-shrink-0 whitespace-nowrap">{t('aiFallback')}</span>
+              )}
+            </div>
+
+            <div className="flex items-center gap-1 pr-1">
+              {/* 返回普通搜索 */}
+              <button
+                type="button"
+                onClick={() => setIsAIMode(false)}
+                className="text-xs text-gray-500 hover:text-gray-700 px-2 py-1 rounded-full hover:bg-white/60 transition-colors whitespace-nowrap"
+              >
+                {t('normalSearch')}
+              </button>
+              {/* AI 搜索按钮 */}
+              <button
+                type="button"
+                onClick={handleAISubmit}
+                disabled={isAILoading || !aiQuery.trim()}
+                className="flex items-center justify-center bg-airbnb hover:bg-airbnb_dark text-white rounded-full transition-all disabled:opacity-40 disabled:cursor-not-allowed shadow-md hover:shadow-lg hover:scale-105 active:scale-95"
+                style={{
+                  width: `calc(var(--search-height, 48px) * 0.8)`,
+                  height: `calc(var(--search-height, 48px) * 0.8)`,
+                  minWidth: '36px',
+                  minHeight: '36px'
+                }}
+                aria-label={t('aiSearch')}
+              >
+                {isAILoading ? (
+                  <span className="animate-spin w-4 h-4 border-2 border-white border-t-transparent rounded-full" />
+                ) : (
+                  <SparkleIcon className="w-4 h-4" />
+                )}
+              </button>
+            </div>
+          </motion.div>
+        ) : (
+          /* ─── 普通筛选搜索条（大屏） ─── */
+          <motion.div
+            key="normal-bar"
+            initial={{opacity: 0, scale: 0.97}}
+            animate={{opacity: 1, scale: 1}}
+            exit={{opacity: 0, scale: 0.97}}
+            transition={{duration: 0.18}}
+            className="hidden lg:flex search-filters-container w-full items-center justify-between border rounded-full transition-all duration-500 ease-in-out relative"
+            style={{height: 'var(--search-height, 48px)'}}
+          >
         <div className="flex-1 flex">
           <div className="flex flex-row items-center justify-between w-full">
             {/* 目的地 */}
@@ -152,8 +255,24 @@ function SearchFiltersContent() {
             </div>
           </div>
 
-          {/* 搜索按钮（大屏） */}
-          <div className="ml-2">
+          <div className="flex items-center gap-1 ml-2">
+            {/* AI 模式切换按钮 */}
+            <button
+              type="button"
+              onClick={switchToAI}
+              className="flex items-center justify-center rounded-full text-airbnb hover:bg-red-50 transition-all duration-200 hover:scale-105 active:scale-95"
+              style={{
+                width: `calc(var(--search-height, 48px) * 0.7)`,
+                height: `calc(var(--search-height, 48px) * 0.7)`,
+                minWidth: '32px',
+                minHeight: '32px'
+              }}
+              aria-label={t('aiToggle')}
+              title={t('aiToggle')}
+            >
+              <SparkleIcon className="w-4 h-4" />
+            </button>
+            {/* 搜索按钮（大屏） */}
             <button
               className="cursor-pointer flex items-center justify-center bg-airbnb hover:bg-airbnb_dark transition-all duration-300 rounded-full text-white shadow-md hover:shadow-lg hover:scale-105 active:scale-95 disabled:opacity-60"
               onClick={handleSearch}
@@ -166,7 +285,6 @@ function SearchFiltersContent() {
                 minHeight: '40px'
               }}
             >
-              {/* 放大镜 */}
               <svg
                 viewBox="0 0 32 32"
                 style={{display:'block', fill:'none', height:'18px', width:'18px', stroke:'currentColor', strokeWidth:4, overflow:'visible'}}
@@ -240,10 +358,14 @@ function SearchFiltersContent() {
             </motion.div>
           )}
         </AnimatePresence>
-      </div>
+          </motion.div>
+        )}
+      </AnimatePresence>
 
-      {/* 小屏精简搜索条 */}
-      <div className="lg:hidden search-btn-container flex items-center">
+      {/* ═══ 小屏搜索条 ═══ */}
+      <div className="lg:hidden search-btn-container flex items-center gap-2">
+        {/* AI 模式切换（小屏） */}
+        {!isAIMode ? (
         <div
           className="h-[46px] w-[180px] sm:w-[220px] border rounded-full flex items-center justify-between px-2 sm:px-3 relative cursor-pointer transition-all duration-300 hover:shadow-md hover:bg-gray-50"
           onClick={handleSearch}
@@ -253,20 +375,73 @@ function SearchFiltersContent() {
               {state.location ? state.location : t('anywhere')}
             </span>
           </div>
-          <button
-            className="w-9 h-9 flex items-center justify-center bg-airbnb hover:bg-airbnb_dark transition-all duration-300 rounded-full text-white shadow-sm hover:shadow-md hover:scale-105 active:scale-95"
-            onClick={e => { e.stopPropagation(); handleSearch(); }}
-            aria-label={t('search')}
-          >
-            <svg
-              viewBox="0 0 32 32"
-              style={{display:'block', fill:'none', height:'15px', width:'15px', stroke:'currentColor', strokeWidth:4, overflow:'visible'}}
-              aria-hidden="true" role="presentation" focusable="false"
+          <div className="flex items-center gap-1">
+            <button
+              type="button"
+              onClick={e => { e.stopPropagation(); switchToAI(); }}
+              className="w-8 h-8 flex items-center justify-center text-airbnb hover:bg-red-50 rounded-full transition-colors"
+              aria-label={t('aiToggle')}
             >
-              <path fill="none" d="M13 24a11 11 0 1 0 0-22 11 11 0 0 0 0 22zm8-3 9 9"></path>
-            </svg>
-          </button>
+              <SparkleIcon className="w-3.5 h-3.5" />
+            </button>
+            <button
+              className="w-9 h-9 flex items-center justify-center bg-airbnb hover:bg-airbnb_dark transition-all duration-300 rounded-full text-white shadow-sm hover:shadow-md hover:scale-105 active:scale-95"
+              onClick={e => { e.stopPropagation(); handleSearch(); }}
+              aria-label={t('search')}
+            >
+              <svg
+                viewBox="0 0 32 32"
+                style={{display:'block', fill:'none', height:'15px', width:'15px', stroke:'currentColor', strokeWidth:4, overflow:'visible'}}
+                aria-hidden="true" role="presentation" focusable="false"
+              >
+                <path fill="none" d="M13 24a11 11 0 1 0 0-22 11 11 0 0 0 0 22zm8-3 9 9"></path>
+              </svg>
+            </button>
+          </div>
         </div>
+        ) : (
+          /* ─── AI 搜索（小屏） ─── */
+          <div
+            className="h-[46px] w-[220px] sm:w-[280px] border border-red-200 rounded-full flex items-center px-2 sm:px-3 relative transition-all duration-300"
+            style={{background: 'linear-gradient(135deg, #fff1f3 0%, #ffe4e8 100%)'}}
+          >
+            <input
+              ref={aiInputRef}
+              type="text"
+              value={aiQuery}
+              onChange={e => setAIQuery(e.target.value)}
+              onKeyDown={handleAIKeyDown}
+              placeholder={t('aiPlaceholder')}
+              className="flex-1 text-xs bg-transparent outline-none text-gray-800 placeholder:text-gray-400 min-w-0"
+              disabled={isAILoading}
+            />
+            <div className="flex items-center gap-1 flex-shrink-0">
+              <button
+                type="button"
+                onClick={() => setIsAIMode(false)}
+                className="w-7 h-7 flex items-center justify-center text-gray-400 hover:text-gray-600 hover:bg-white/60 rounded-full transition-colors"
+                aria-label={t('normalSearch')}
+              >
+                <svg className="w-3.5 h-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+                  <path strokeLinecap="round" strokeLinejoin="round" d="M6 18L18 6M6 6l12 12" />
+                </svg>
+              </button>
+              <button
+                type="button"
+                onClick={handleAISubmit}
+                disabled={isAILoading || !aiQuery.trim()}
+                className="w-9 h-9 flex items-center justify-center bg-airbnb hover:bg-airbnb_dark text-white rounded-full transition-all disabled:opacity-40 shadow-sm hover:shadow-md hover:scale-105 active:scale-95"
+                aria-label={t('aiSearch')}
+              >
+                {isAILoading ? (
+                  <span className="animate-spin w-3.5 h-3.5 border-2 border-white border-t-transparent rounded-full" />
+                ) : (
+                  <SparkleIcon className="w-3.5 h-3.5" />
+                )}
+              </button>
+            </div>
+          </div>
+        )}
       </div>
 
       <AnimatePresence>


### PR DESCRIPTION
Integrate LLM-powered search that parses natural language queries into structured filters (location, dates, guests, bedrooms, price, category).

Backend:
- Extend property API with bedrooms, bathrooms, price range, place_type filters

Frontend:
- Add BFF route /api/search/ai-parse with OpenRouter LLM function calling
- Add shared server-only LLM client (src/shared/ai/llm-client.ts)
- Add useAISearch hook with empty-params fallback to keyword search
- Integrate AI search toggle into Navbar SearchFilters (desktop + mobile)
- Extend SearchState/SearchParams types for new filter fields
- Add i18n keys for AI search UI (en/zh/fr)
- Theme AI search UI to match project primary color (#ff385c)
- Add AI features roadmap document

Made-with: Cursor