### PR TITLE
feat(ai): P1 review insights, per-locale summaries, lazy OpenAI client

### DIFF
--- a/airnest_backend/backend/property/api.py
+++ b/airnest_backend/backend/property/api.py
@@ -12,7 +12,7 @@ from .cache_utils import (
 
 from datetime import datetime, timedelta
 import pytz
-from .models import Property, PropertyImage, Reservation, Wishlist, PropertyReview, ReviewTag, ReviewTagAssignment, ALLOWED_PROPERTY_TAG_IDS
+from .models import Property, PropertyImage, Reservation, Wishlist, PropertyReview, ReviewTag, ReviewTagAssignment, PropertyReviewSummary, ALLOWED_PROPERTY_TAG_IDS
 import json
 from .serializers import PropertySerializer, PropertyLandlordSerializer, PropertyImageSerializer, PropertyReviewSerializer, PropertyReviewListSerializer, ReviewTagSerializer, PropertyWithReviewStatsSerializer
 from .forms import PropertyForm
@@ -749,6 +749,11 @@ def property_reviews(request, pk):
                     reservation=latest_reservation if latest_reservation else None,
                     is_verified=bool(latest_reservation)
                 )
+                # Mark all AI review summaries for this property as stale
+                PropertyReviewSummary.objects.filter(
+                    property_ref=property_obj
+                ).update(is_stale=True)
+
                 response_serializer = PropertyReviewListSerializer(review)
                 return JsonResponse(response_serializer.data, status=201)
             else:
@@ -1129,3 +1134,52 @@ def publish_property(request, pk):
     except Exception as e:
         print(f"Error publishing property: {e}")
         return JsonResponse({'error': str(e)}, status=400)
+
+
+@api_view(['GET', 'PUT'])
+@authentication_classes([])
+@permission_classes([])
+def ai_review_summary(request, pk):
+    """
+    GET: Return cached AI review summary for property+locale (or 404).
+    PUT: Upsert an AI-generated review summary (called by BFF after LLM generation).
+    """
+    locale = request.GET.get('locale', 'en')
+
+    if request.method == 'GET':
+        try:
+            summary = PropertyReviewSummary.objects.get(
+                property_ref_id=pk, locale=locale
+            )
+            return JsonResponse({
+                'highlights': summary.highlights,
+                'concerns': summary.concerns,
+                'best_for': summary.best_for,
+                'summary_text': summary.summary_text,
+                'reviews_count_at_generation': summary.reviews_count_at_generation,
+                'is_stale': summary.is_stale,
+                'generated_at': summary.generated_at.isoformat(),
+                'model_version': summary.model_version,
+            })
+        except PropertyReviewSummary.DoesNotExist:
+            return JsonResponse({'error': 'No summary found'}, status=404)
+
+    elif request.method == 'PUT':
+        try:
+            data = json.loads(request.body)
+            summary, _ = PropertyReviewSummary.objects.update_or_create(
+                property_ref_id=pk,
+                locale=locale,
+                defaults={
+                    'highlights': data.get('highlights', []),
+                    'concerns': data.get('concerns', []),
+                    'best_for': data.get('best_for', []),
+                    'summary_text': data.get('summary_text', ''),
+                    'reviews_count_at_generation': data.get('reviews_count_at_generation', 0),
+                    'is_stale': False,
+                    'model_version': data.get('model_version', ''),
+                },
+            )
+            return JsonResponse({'status': 'ok', 'id': str(summary.id)})
+        except Exception as e:
+            return JsonResponse({'error': str(e)}, status=400)

--- a/airnest_backend/backend/property/migrations/0022_add_property_review_summary.py
+++ b/airnest_backend/backend/property/migrations/0022_add_property_review_summary.py
@@ -1,0 +1,36 @@
+import uuid
+from django.db import migrations, models
+import django.db.models.deletion
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('property', '0021_add_property_tags'),
+    ]
+
+    operations = [
+        migrations.CreateModel(
+            name='PropertyReviewSummary',
+            fields=[
+                ('id', models.UUIDField(default=uuid.uuid4, editable=False, primary_key=True, serialize=False)),
+                ('locale', models.CharField(default='en', max_length=10)),
+                ('highlights', models.JSONField(default=list)),
+                ('concerns', models.JSONField(default=list)),
+                ('best_for', models.JSONField(default=list)),
+                ('summary_text', models.TextField(blank=True)),
+                ('reviews_count_at_generation', models.IntegerField(default=0)),
+                ('is_stale', models.BooleanField(default=False)),
+                ('generated_at', models.DateTimeField(auto_now=True)),
+                ('model_version', models.CharField(default='', max_length=50)),
+                ('property_ref', models.ForeignKey(
+                    on_delete=django.db.models.deletion.CASCADE,
+                    related_name='ai_review_summaries',
+                    to='property.property',
+                )),
+            ],
+            options={
+                'unique_together': {('property_ref', 'locale')},
+            },
+        ),
+    ]

--- a/airnest_backend/backend/property/models.py
+++ b/airnest_backend/backend/property/models.py
@@ -258,3 +258,28 @@ class ReviewTagAssignment(models.Model):
     
     def __str__(self):
         return f"{self.review.id} - {self.tag.tag_key}"
+
+
+class PropertyReviewSummary(models.Model):
+    """AI-generated review insights, cached per property per locale."""
+    id = models.UUIDField(primary_key=True, default=uuid.uuid4, editable=False)
+    property_ref = models.ForeignKey(
+        Property, related_name='ai_review_summaries', on_delete=models.CASCADE
+    )
+    locale = models.CharField(max_length=10, default='en')
+
+    highlights = models.JSONField(default=list)
+    concerns = models.JSONField(default=list)
+    best_for = models.JSONField(default=list)
+    summary_text = models.TextField(blank=True)
+
+    reviews_count_at_generation = models.IntegerField(default=0)
+    is_stale = models.BooleanField(default=False)
+    generated_at = models.DateTimeField(auto_now=True)
+    model_version = models.CharField(max_length=50, default='')
+
+    class Meta:
+        unique_together = ['property_ref', 'locale']
+
+    def __str__(self):
+        return f"AI Summary for {self.property_ref.title} ({self.locale})"

--- a/airnest_backend/backend/property/urls.py
+++ b/airnest_backend/backend/property/urls.py
@@ -25,4 +25,5 @@ urlpatterns = [
     path('<uuid:pk>/reviews/', api.property_reviews, name='api_property_reviews'),
     path('<uuid:pk>/review-stats/', api.property_review_stats, name='api_property_review_stats'),
     path('reviews/<uuid:review_id>/', api.manage_review, name='api_manage_review'),
+    path('<uuid:pk>/ai-review-summary/', api.ai_review_summary, name='api_ai_review_summary'),
 ]

--- a/airnest_frontend/app/api/reviews/[propertyId]/ai-summary/route.ts
+++ b/airnest_frontend/app/api/reviews/[propertyId]/ai-summary/route.ts
@@ -1,0 +1,208 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { callWithTools, type ToolCallResult } from '@/src/shared/ai/llm-client';
+import type OpenAI from 'openai';
+
+const BACKEND_API_URL = process.env.NEXT_PUBLIC_API_URL;
+const MIN_REVIEWS_FOR_SUMMARY = 3;
+
+interface ReviewInsights {
+  highlights: string[];
+  concerns: string[];
+  best_for: string[];
+  summary_text: string;
+}
+
+interface BackendReview {
+  id: string;
+  rating: number;
+  title?: string;
+  content: string;
+  user?: { name?: string };
+  created_at?: string;
+}
+
+interface CachedSummary {
+  highlights: string[];
+  concerns: string[];
+  best_for: string[];
+  summary_text: string;
+  reviews_count_at_generation: number;
+  is_stale: boolean;
+  generated_at: string;
+  model_version: string;
+}
+
+const LOCALE_NAMES: Record<string, string> = {
+  en: 'English',
+  zh: 'Chinese (Simplified, 简体中文)',
+  fr: 'French (Français)',
+};
+
+function buildSystemPrompt(locale: string) {
+  const langName = LOCALE_NAMES[locale] || 'English';
+  return `You are a review analyst for a vacation rental platform.
+Analyze the provided guest reviews and extract structured insights.
+
+CRITICAL: ALL output text MUST be written in ${langName}. Even if the reviews are in another language, you MUST translate and write every string value in ${langName}.
+${locale === 'zh' ? 'You MUST write in 简体中文. Example: "位置绝佳", "房东热情好客", "适合情侣".' : ''}
+${locale === 'fr' ? 'You MUST write in français. Example: "Emplacement idéal", "Hôte très accueillant".' : ''}
+
+Rules:
+- highlights: 3-5 most frequently praised aspects. Be specific and concise (under 15 words each). Written in ${langName}.
+- concerns: 0-3 common complaints or things to be aware of. Only include if genuinely mentioned by multiple guests or particularly noteworthy. If reviews are overwhelmingly positive, return an empty array. Written in ${langName}.
+- best_for: 2-4 traveler types this property suits. Written in ${langName}.
+- summary_text: A single sentence (under 30 words) capturing the overall sentiment. Written in ${langName}.
+- Base your analysis strictly on the reviews provided. Do not invent information.`;
+}
+
+const insightsTool: OpenAI.ChatCompletionTool = {
+  type: 'function',
+  function: {
+    name: 'submit_review_insights',
+    description: 'Submit structured insights extracted from guest reviews.',
+    parameters: {
+      type: 'object',
+      properties: {
+        highlights: {
+          type: 'array',
+          items: { type: 'string' },
+          description: 'Top praised aspects (3-5 items)',
+        },
+        concerns: {
+          type: 'array',
+          items: { type: 'string' },
+          description: 'Common concerns or warnings (0-3 items)',
+        },
+        best_for: {
+          type: 'array',
+          items: { type: 'string' },
+          description: 'Ideal traveler types (2-4 items)',
+        },
+        summary_text: {
+          type: 'string',
+          description: 'One-sentence overall summary (under 30 words)',
+        },
+      },
+      required: ['highlights', 'concerns', 'best_for', 'summary_text'],
+    },
+  },
+};
+
+export async function GET(
+  request: NextRequest,
+  { params }: { params: Promise<{ propertyId: string }> }
+) {
+  const { propertyId } = await params;
+  const locale = request.nextUrl.searchParams.get('locale') || 'en';
+
+  try {
+    // 1. Check backend cache
+    const cacheRes = await fetch(
+      `${BACKEND_API_URL}/api/properties/${propertyId}/ai-review-summary/?locale=${locale}`,
+    );
+
+    if (cacheRes.ok) {
+      const cached: CachedSummary = await cacheRes.json();
+      if (!cached.is_stale) {
+        return NextResponse.json({
+          ...cached,
+          source: 'cache',
+        });
+      }
+      // stale — fall through to regenerate
+    }
+
+    // 2. Check if we have an API key
+    if (!process.env.OPENROUTER_API_KEY) {
+      return NextResponse.json(
+        { error: 'AI service not configured' },
+        { status: 503 },
+      );
+    }
+
+    // 3. Fetch reviews from backend
+    const reviewsRes = await fetch(
+      `${BACKEND_API_URL}/api/properties/${propertyId}/reviews/?page_size=50`,
+    );
+    if (!reviewsRes.ok) {
+      return NextResponse.json({ error: 'Failed to fetch reviews' }, { status: 502 });
+    }
+    const reviewsData = await reviewsRes.json();
+    const reviews: BackendReview[] = reviewsData.reviews || [];
+    const totalCount: number = reviewsData.total_count || reviews.length;
+
+    if (totalCount < MIN_REVIEWS_FOR_SUMMARY) {
+      return NextResponse.json({
+        error: 'not_enough_reviews',
+        min_required: MIN_REVIEWS_FOR_SUMMARY,
+        current_count: totalCount,
+      }, { status: 404 });
+    }
+
+    // 4. Build prompt with review text
+    const reviewTexts = reviews
+      .map((r, i) => `Review ${i + 1} (${r.rating}/5): ${r.title ? r.title + ' — ' : ''}${r.content}`)
+      .join('\n');
+
+    const langName = LOCALE_NAMES[locale] || 'English';
+    const userMessage = `Output language: ${langName}\nTotal reviews: ${totalCount}\n\n${reviewTexts}\n\nREMINDER: Write ALL output values in ${langName}. Do NOT use English unless the output language is English.`;
+
+    // 5. Call LLM
+    const model = process.env.AI_MODEL || 'google/gemini-2.0-flash-001';
+    const result: ToolCallResult<ReviewInsights> = await callWithTools<ReviewInsights>({
+      messages: [
+        { role: 'system', content: buildSystemPrompt(locale) },
+        { role: 'user', content: userMessage },
+      ],
+      tools: [insightsTool],
+      toolChoice: { type: 'function', function: { name: 'submit_review_insights' } },
+      timeoutMs: 12000,
+    });
+
+    if (!result.success || !result.data) {
+      console.error('[AI Review Summary] LLM failed:', result.error);
+      return NextResponse.json(
+        { error: 'AI generation failed', detail: result.error },
+        { status: 502 },
+      );
+    }
+
+    const insights = result.data;
+
+    // 6. Save to backend cache
+    await fetch(
+      `${BACKEND_API_URL}/api/properties/${propertyId}/ai-review-summary/?locale=${locale}`,
+      {
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          highlights: insights.highlights || [],
+          concerns: insights.concerns || [],
+          best_for: insights.best_for || [],
+          summary_text: insights.summary_text || '',
+          reviews_count_at_generation: totalCount,
+          model_version: model,
+        }),
+      },
+    );
+
+    // 7. Return to client
+    return NextResponse.json({
+      highlights: insights.highlights || [],
+      concerns: insights.concerns || [],
+      best_for: insights.best_for || [],
+      summary_text: insights.summary_text || '',
+      reviews_count_at_generation: totalCount,
+      is_stale: false,
+      generated_at: new Date().toISOString(),
+      model_version: model,
+      source: 'generated',
+    });
+  } catch (error) {
+    console.error('[AI Review Summary] Error:', error);
+    return NextResponse.json(
+      { error: 'Internal error' },
+      { status: 500 },
+    );
+  }
+}

--- a/airnest_frontend/src/features/properties/reviews/Reviews.AIInsights.tsx
+++ b/airnest_frontend/src/features/properties/reviews/Reviews.AIInsights.tsx
@@ -1,0 +1,204 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { useLocale, useTranslations } from 'next-intl';
+
+interface AIInsightsData {
+  highlights: string[];
+  concerns: string[];
+  best_for: string[];
+  summary_text: string;
+  reviews_count_at_generation: number;
+  generated_at: string;
+  source?: string;
+}
+
+interface Props {
+  propertyId: string;
+  totalReviews: number;
+}
+
+const HeartIcon = ({ className = 'w-4 h-4' }: { className?: string }) => (
+  <svg className={className} viewBox="0 0 1024 1024" fill="#ff385c">
+    <path d="M512 901.746939c-13.583673 0-26.122449-4.179592-37.093878-13.061225-8.881633-7.314286-225.697959-175.020408-312.424489-311.379592C133.746939 532.37551 94.040816 471.24898 94.040816 384.522449c0-144.718367 108.146939-262.269388 240.326531-262.269388 67.395918 0 131.657143 30.82449 177.632653 84.636735 45.453061-54.334694 109.191837-84.636735 177.110204-84.636735 132.702041 0 240.326531 117.55102 240.326531 262.269388 0 85.159184-37.093878 143.673469-67.395919 191.216327l-1.044898 1.567346c-86.726531 136.359184-303.542857 304.587755-312.424489 311.379592-10.44898 8.359184-22.987755 13.061224-36.571429 13.061225z" />
+  </svg>
+);
+
+const InfoIcon = ({ className = 'w-4 h-4' }: { className?: string }) => (
+  <svg className={className} viewBox="0 0 1024 1024" fill="#ff385c">
+    <path d="M512 147.2C310.528 147.2 147.2 310.528 147.2 512S310.528 876.8 512 876.8 876.8 713.472 876.8 512 713.472 147.2 512 147.2z m0 64c166.144 0 300.8 134.656 300.8 300.8S678.144 812.8 512 812.8 211.2 678.144 211.2 512 345.856 211.2 512 211.2z" />
+    <path d="M478.72 462.3104m33.28 0l0 0q33.28 0 33.28 33.28l0 173.056q0 33.28-33.28 33.28l0 0q-33.28 0-33.28-33.28l0-173.056q0-33.28 33.28-33.28Z" />
+    <path d="M512 370.7136m-48.64 0a48.64 48.64 0 1 0 97.28 0 48.64 48.64 0 1 0-97.28 0Z" />
+  </svg>
+);
+
+const PeopleIcon = ({ className = 'w-4 h-4' }: { className?: string }) => (
+  <svg className={className} viewBox="0 0 1025 1024" fill="#ff385c">
+    <path d="M762.6 88m-88 0a88 88 0 1 0 176 0 88 88 0 1 0-176 0Z" />
+    <path d="M1023.9 570.7l-69.5-260c-18.7-70-82.2-118.7-154.6-118.7H725.5c-33.6 0-65.3 10.5-91.4 28.7-26.2-18.2-57.8-28.7-91.4-28.7h-74.3c-72.4 0-135.9 48.7-154.6 118.7l-69.5 260c-0.9 3.5-1.4 6.9-1.4 10.4 0 16.7 10.6 32.1 26.9 37.8l-13.2 22.9-3.3-11.8c-11.7-41.3-49.4-69.9-92.4-69.9h-29.8c-43.4 0-81.5 29.2-92.7 71.1L0.8 771.2c-0.5 1.9-0.8 3.9-0.8 5.8 0 9.9 6.6 18.9 16.5 21.5 11.9 3.2 24.1-3.9 27.3-15.8l36.2-135c0.6-2.3 3.9-1.8 3.9 0.5V1016c0 4.4 3.6 8 8 8h37.5c4.4 0 8-3.6 8-8V808.9c0-4.4 3.6-8 8-8h1.8c4.4 0 8 3.6 8 8V1016c0 4.4 3.6 8 8 8h37.5c4.4 0 8-3.6 8-8V651.4c0-2.3 3.3-2.8 3.9-0.5l9.4 35c1 3.9 2.9 7.5 5.3 10.7 2.4 3.2 5.5 5.8 9 7.9 14.6 8.4 33.3 3.4 41.8-11.2l39.1-67.7c2-3.5 3-7.3 3-11.1 0-4.3-1.2-8.5-3.6-12.1 2.1-3.3 3.8-7 4.8-11l64.1-239c1.2-4.5 7.9-3.6 7.9 1V1008c0 8.8 7.2 16 16 16h64c8.8 0 16-7.2 16-16V640c0-4.4 1.8-8.4 4.7-11.3 2.9-2.9 6.9-4.7 11.3-4.7 8.8 0 16 7.2 16 16v368c0 8.8 7.2 16 16 16h64c8.8 0 16-7.2 16-16V720h29.2c2.2 0 4 1.8 4 4v284c0 8.8 7.2 16 16 16h64c8.8 0 16-7.2 16-16V724c0-2.2 1.8-4 4-4h24c2.2 0 4 1.8 4 4v284c0 8.8 7.2 16 16 16h64c8.8 0 16-7.2 16-16V724c0-2.2 1.8-4 4-4h38.1c10.8 0 18.5-10.5 15.3-20.8l-48.8-156.8c-5.8-18.5-8.7-37.7-8.7-57.1v-132c0-4.6 6.7-5.5 7.9-1l64.1 239c5.7 21.3 27.7 34 49 28.3 21.5-5.7 34.1-27.6 28.4-48.9z m-373.3-85.4c0 19.4-2.9 38.6-8.7 57.1L617.5 620.9V446.3l16.5-61.6 16.6 61.9v38.7z" />
+    <path d="M147.5 456m-88 0a88 88 0 1 0 176 0 88 88 0 1 0-176 0Z" />
+    <path d="M505.5 88m-88 0a88 88 0 1 0 176 0 88 88 0 1 0-176 0Z" />
+  </svg>
+);
+
+function Skeleton() {
+  return (
+    <div className="animate-pulse rounded-2xl border border-gray-100 bg-gray-50/60 p-6">
+      <div className="flex items-center gap-2 mb-5">
+        <div className="w-5 h-5 bg-gray-200 rounded" />
+        <div className="h-5 bg-gray-200 rounded w-32" />
+        <div className="ml-auto h-4 bg-gray-200 rounded w-20" />
+      </div>
+      <div className="h-4 bg-gray-200 rounded w-2/3 mb-5" />
+      <div className="flex flex-wrap gap-2 mb-4">
+        {[1, 2, 3, 4].map(i => (
+          <div key={i} className="h-8 bg-gray-200 rounded-full w-28" />
+        ))}
+      </div>
+      <div className="flex flex-wrap gap-2">
+        {[1, 2].map(i => (
+          <div key={i} className="h-8 bg-gray-200 rounded-full w-32" />
+        ))}
+      </div>
+    </div>
+  );
+}
+
+export default function ReviewsAIInsights({ propertyId, totalReviews }: Props) {
+  const locale = useLocale();
+  const t = useTranslations('reviews');
+  const [data, setData] = useState<AIInsightsData | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState(false);
+
+  useEffect(() => {
+    if (totalReviews < 3) return;
+
+    let cancelled = false;
+    (async () => {
+      setLoading(true);
+      setError(false);
+      try {
+        const res = await fetch(`/api/reviews/${propertyId}/ai-summary?locale=${locale}`);
+        if (!res.ok) throw new Error(`HTTP ${res.status}`);
+        const json = await res.json();
+        if (!cancelled) setData(json);
+      } catch {
+        if (!cancelled) setError(true);
+      } finally {
+        if (!cancelled) setLoading(false);
+      }
+    })();
+    return () => { cancelled = true; };
+  }, [propertyId, locale, totalReviews]);
+
+  if (totalReviews < 3) return null;
+  if (error) return null;
+  if (loading) return <Skeleton />;
+  if (!data) return null;
+
+  const hasHighlights = data.highlights.length > 0;
+  const hasConcerns = data.concerns.length > 0;
+  const hasBestFor = data.best_for.length > 0;
+
+  if (!hasHighlights && !hasConcerns && !hasBestFor) return null;
+
+  const relativeTime = (() => {
+    if (!data.generated_at) return '';
+    const diff = Date.now() - new Date(data.generated_at).getTime();
+    const hours = Math.floor(diff / 3600000);
+    if (hours < 1) return t('aiJustNow');
+    if (hours < 24) return t('aiHoursAgo', { count: hours });
+    const days = Math.floor(hours / 24);
+    return t('aiDaysAgo', { count: days });
+  })();
+
+  return (
+    <div className="rounded-2xl border border-red-100/80 bg-gradient-to-br from-rose-50/60 via-white to-rose-50/30 p-6 mb-6 shadow-sm">
+      {/* Header */}
+      <div className="flex items-center justify-between mb-3">
+        <div className="flex items-center gap-2.5">
+          <div className="w-7 h-7 rounded-full bg-airbnb/10 flex items-center justify-center">
+            <svg className="w-4 h-4 text-airbnb" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={2}>
+              <path strokeLinecap="round" strokeLinejoin="round" d="M9.813 15.904L9 18.75l-.813-2.846a4.5 4.5 0 00-3.09-3.09L2.25 12l2.846-.813a4.5 4.5 0 003.09-3.09L9 5.25l.813 2.846a4.5 4.5 0 003.09 3.09L15.75 12l-2.846.813a4.5 4.5 0 00-3.09 3.09zM18.259 8.715L18 9.75l-.259-1.035a3.375 3.375 0 00-2.455-2.456L14.25 6l1.036-.259a3.375 3.375 0 002.455-2.456L18 2.25l.259 1.035a3.375 3.375 0 002.455 2.456L21.75 6l-1.036.259a3.375 3.375 0 00-2.455 2.456z" />
+            </svg>
+          </div>
+          <h3 className="font-semibold text-gray-900">{t('aiInsightsTitle')}</h3>
+          <span className="text-xs text-gray-400 bg-gray-100 px-2 py-0.5 rounded-full">
+            {t('aiBasedOn', { count: data.reviews_count_at_generation })}
+          </span>
+        </div>
+        {relativeTime && (
+          <span className="text-xs text-gray-400">{relativeTime}</span>
+        )}
+      </div>
+
+      {/* Summary sentence */}
+      {data.summary_text && (
+        <p className="text-sm text-gray-600 mb-5 leading-relaxed">&ldquo;{data.summary_text}&rdquo;</p>
+      )}
+
+      <div className="space-y-5">
+        {/* Highlights */}
+        {hasHighlights && (
+          <div>
+            <div className="flex items-center gap-2 mb-3">
+              <HeartIcon className="w-4 h-4 flex-shrink-0" />
+              <span className="text-sm font-semibold text-gray-800">{t('aiHighlights')}</span>
+            </div>
+            <div className="flex flex-wrap gap-2">
+              {data.highlights.map((h, i) => (
+                <span
+                  key={i}
+                  className="text-xs px-3.5 py-1.5 rounded-full bg-white text-gray-700 border border-gray-200/80 shadow-sm font-medium transition-all hover:shadow-md hover:border-airbnb/30"
+                >
+                  {h}
+                </span>
+              ))}
+            </div>
+          </div>
+        )}
+
+        {/* Concerns */}
+        {hasConcerns && (
+          <div>
+            <div className="flex items-center gap-2 mb-3">
+              <InfoIcon className="w-4 h-4 flex-shrink-0" />
+              <span className="text-sm font-semibold text-gray-800">{t('aiConcerns')}</span>
+            </div>
+            <div className="flex flex-wrap gap-2">
+              {data.concerns.map((c, i) => (
+                <span
+                  key={i}
+                  className="text-xs px-3.5 py-1.5 rounded-full bg-white text-gray-600 border border-amber-200/80 shadow-sm font-medium transition-all hover:shadow-md hover:border-amber-300"
+                >
+                  {c}
+                </span>
+              ))}
+            </div>
+          </div>
+        )}
+
+        {/* Best for */}
+        {hasBestFor && (
+          <div>
+            <div className="flex items-center gap-2 mb-3">
+              <PeopleIcon className="w-4 h-4 flex-shrink-0" />
+              <span className="text-sm font-semibold text-gray-800">{t('aiBestFor')}</span>
+            </div>
+            <div className="flex flex-wrap gap-2">
+              {data.best_for.map((b, i) => (
+                <span
+                  key={i}
+                  className="text-xs px-3.5 py-1.5 rounded-full bg-airbnb/5 text-airbnb border border-airbnb/15 shadow-sm font-semibold transition-all hover:shadow-md hover:bg-airbnb/10"
+                >
+                  {b}
+                </span>
+              ))}
+            </div>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/airnest_frontend/src/features/properties/reviews/Reviews.Container.tsx
+++ b/airnest_frontend/src/features/properties/reviews/Reviews.Container.tsx
@@ -7,6 +7,7 @@ import { useLoginModal } from '@auth/client/modalStore';
 import apiService from '@auth/client/clientApiService';
 import toast from 'react-hot-toast';
 import ReviewsSummary from './Reviews.Summary';
+import ReviewsAIInsights from './Reviews.AIInsights';
 import ReviewsList from './Reviews.List';
 import ReviewsForm from './Reviews.Form';
 import Button from '@sharedUI/Button';
@@ -157,6 +158,11 @@ export default function Reviews({ propertyId, propertyStatus }: ReviewsProps) {
       {/* summary */}
       {stats && stats.total_reviews > 0 && (
         <ReviewsSummary stats={stats} />
+      )}
+
+      {/* AI insights */}
+      {stats && (
+        <ReviewsAIInsights propertyId={propertyId} totalReviews={stats.total_reviews} />
       )}
 
       {/* form */}

--- a/airnest_frontend/src/shared/ai/llm-client.ts
+++ b/airnest_frontend/src/shared/ai/llm-client.ts
@@ -1,10 +1,24 @@
 import 'server-only';
 import OpenAI from 'openai';
 
-const openai = new OpenAI({
-  baseURL: 'https://openrouter.ai/api/v1',
-  apiKey: process.env.OPENROUTER_API_KEY,
-});
+/**
+ * Do not instantiate OpenAI at module load. During `next build` (e.g. Vercel),
+ * OPENROUTER_API_KEY may be unset; the SDK throws if apiKey is missing.
+ * Lazy-init only when a key exists so route modules can import this file safely.
+ */
+let openaiClient: OpenAI | null = null;
+
+function getOpenAI(): OpenAI | null {
+  const key = process.env.OPENROUTER_API_KEY;
+  if (!key) return null;
+  if (!openaiClient) {
+    openaiClient = new OpenAI({
+      baseURL: 'https://openrouter.ai/api/v1',
+      apiKey: key,
+    });
+  }
+  return openaiClient;
+}
 
 const DEFAULT_MODEL = process.env.AI_MODEL || 'google/gemini-2.0-flash-001';
 const DEFAULT_TIMEOUT = Number(process.env.AI_TIMEOUT_MS) || 8000;
@@ -28,6 +42,16 @@ export async function callWithTools<T>(options: {
   timeoutMs?: number;
 }): Promise<ToolCallResult<T>> {
   const { messages, tools, toolChoice, model = DEFAULT_MODEL, timeoutMs = DEFAULT_TIMEOUT } = options;
+
+  const openai = getOpenAI();
+  if (!openai) {
+    return {
+      success: false,
+      data: null,
+      fallback: true,
+      error: 'AI service not configured (OPENROUTER_API_KEY)',
+    };
+  }
 
   const controller = new AbortController();
   const timer = setTimeout(() => controller.abort(), timeoutMs);

--- a/airnest_frontend/src/shared/i18n/messages/en.json
+++ b/airnest_frontend/src/shared/i18n/messages/en.json
@@ -200,7 +200,15 @@
     "titlePlaceholder": "Give your review a title...",
     "contentPlaceholder": "Share your experience with this property...",
     "showAllReviews": "Show all {count} more reviews",
-    "showLess": "Show less reviews"
+    "showLess": "Show less reviews",
+    "aiInsightsTitle": "AI Review Insights",
+    "aiBasedOn": "Based on {count} reviews",
+    "aiHighlights": "Guest favorites",
+    "aiConcerns": "Good to know",
+    "aiBestFor": "Best for",
+    "aiJustNow": "Just updated",
+    "aiHoursAgo": "{count}h ago",
+    "aiDaysAgo": "{count}d ago"
   },
   
   "myproperties": {

--- a/airnest_frontend/src/shared/i18n/messages/fr.json
+++ b/airnest_frontend/src/shared/i18n/messages/fr.json
@@ -225,7 +225,15 @@
     "titlePlaceholder": "Donnez un titre à votre avis...",
     "contentPlaceholder": "Partagez votre expérience avec cette propriété...",
     "showAllReviews": "Afficher les {count} autres avis",
-    "showLess": "Afficher moins d'avis"
+    "showLess": "Afficher moins d'avis",
+    "aiInsightsTitle": "Avis IA en un coup d'œil",
+    "aiBasedOn": "Basé sur {count} avis",
+    "aiHighlights": "Ce que les voyageurs adorent",
+    "aiConcerns": "Bon à savoir",
+    "aiBestFor": "Idéal pour",
+    "aiJustNow": "Mis à jour à l'instant",
+    "aiHoursAgo": "Il y a {count}h",
+    "aiDaysAgo": "Il y a {count}j"
   },
   "errors": {
     "NETWORK_ERROR": "Erreur de réseau. Veuillez vérifier votre connexion Internet.",

--- a/airnest_frontend/src/shared/i18n/messages/zh.json
+++ b/airnest_frontend/src/shared/i18n/messages/zh.json
@@ -201,7 +201,15 @@
     "titlePlaceholder": "为您的评论起个标题...",
     "contentPlaceholder": "分享您对这处房源的体验...",
     "showAllReviews": "显示全部 {count} 条评论",
-    "showLess": "收起评论"
+    "showLess": "收起评论",
+    "aiInsightsTitle": "AI 评论洞察",
+    "aiBasedOn": "基于 {count} 条评论",
+    "aiHighlights": "住客最爱",
+    "aiConcerns": "值得注意",
+    "aiBestFor": "最适合",
+    "aiJustNow": "刚刚更新",
+    "aiHoursAgo": "{count}小时前",
+    "aiDaysAgo": "{count}天前"
   },
 
   "myproperties": {


### PR DESCRIPTION
- Add PropertyReviewSummary model, migration, GET/PUT ai-review-summary API
- Mark summaries stale on new reviews; wire BFF /api/reviews/[id]/ai-summary
- Add Reviews.AIInsights UI, i18n (en/zh/fr), integrate in Reviews.Container
- Locale-aware LLM prompts for translated highlights/concerns/summary
- Lazy-init OpenRouter client so next build succeeds without OPENROUTER_API_KEY
